### PR TITLE
fix(tls): prevent cert file deletion on config form resubmission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [unreleased]: https://github.com/shiftysheep/CTFd-Docker-Challenges/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/shiftysheep/CTFd-Docker-Challenges/releases/tag/v1.0.0
 
+## v3.1.1 (2026-02-12)
+
+### Fix
+
+- **tls**: prevent cert file deletion on config form resubmission
+
 ## v3.1.0 (2026-02-12)
 
 ### Feat

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plugin for CTFd allows competing teams/users to start dockerized images for
 
 > **For Contributors**: See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code quality standards, and contribution guidelines.
 
-## Version 3.1.0
+## Version 3.1.1
 
 **Latest Update**: Migrated to Alpine.js and Bootstrap 5 for CTFd 3.8.0+ (core theme)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctfd-docker-challenges"
-version = "3.1.0"
+version = "3.1.1"
 description = "Docker-based challenge support for CTFd"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,14 +120,20 @@ def mock_docker_config():
 
 
 @pytest.fixture
-def mock_docker_config_tls():
-    """Mock DockerConfig with TLS enabled."""
+def mock_docker_config_tls(tmp_path):
+    """Mock DockerConfig with TLS enabled and real temp cert files."""
+    ca = tmp_path / "ca.pem"
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    for f in (ca, cert, key):
+        f.write_text("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n")
+
     config = MagicMock()
     config.hostname = "localhost:2376"
     config.tls_enabled = True
-    config.ca_cert = "/path/to/ca.pem"
-    config.client_cert = "/path/to/cert.pem"
-    config.client_key = "/path/to/key.pem"
+    config.ca_cert = str(ca)
+    config.client_cert = str(cert)
+    config.client_key = str(key)
     config.repositories = None
     return config
 

--- a/uv.lock
+++ b/uv.lock
@@ -396,7 +396,7 @@ toml = [
 
 [[package]]
 name = "ctfd-docker-challenges"
-version = "3.1.0"
+version = "3.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
__handle_file_upload deleted existing TLS temp files before checking if replacement content was provided. Empty form submissions (no new file selected) left database paths pointing to deleted files, causing X509: NO_CERTIFICATE_OR_CRL_FOUND errors on subsequent Docker API calls.