### PR TITLE
fix(frontend): replace bootstrap.Modal with vanilla JS helpers

### DIFF
--- a/agent-docs/architecture/limitations.md
+++ b/agent-docs/architecture/limitations.md
@@ -40,12 +40,12 @@ This is a **LIVING DOCUMENT**. Agents working in this codebase should add discov
 - **Workaround**: Use global scope functions in `view.js` (expose to `window`). Admin forms can use ES6 modules (full page loads).
 - **Reference**: `assets/view.js`, `CLAUDE.md` - "JavaScript/Frontend Development"
 
-### Bootstrap Tooltips - Not Available in Core Theme
+### Bootstrap JS API - Not Available as Global
 
-- **Issue**: CTFd core theme doesn't expose `bootstrap` as global variable, tooltip initialization fails
-- **Impact**: Removed tooltip functionality from v3.0.0+ (feature removal, not critical)
-- **Workaround**: None - tooltips removed from UI
-- **Reference**: v3.0.0 release notes, `CLAUDE.md` - "Fixed in v3.0.0"
+- **Issue**: CTFd does not expose `bootstrap` as a reliable global variable for plugins. The admin theme uses Bootstrap 4 via jQuery compat layer; the core theme uses Bootstrap 5 CSS + Alpine.js. Neither exposes `bootstrap.Modal` for direct use.
+- **Impact**: Any code calling `new bootstrap.Modal()` or `bootstrap.Modal.getInstance()` throws `ReferenceError: bootstrap is not defined`
+- **Workaround**: Use vanilla JS modal toggling (CSS class manipulation) instead of `bootstrap.Modal` API. Shared helper in `assets/shared/modalUtils.js` exports `showModal()`, `hideModal()`, and `bindDismissButtons()`. Inline scripts in templates define equivalent functions locally (can't import ES modules in inline scripts).
+- **Reference**: `assets/shared/modalUtils.js`, `templates/admin_docker_secrets.html`, `templates/admin_docker_status.html`, `assets/view.js`
 
 ### Dynamic Form Loading - DOMContentLoaded Conflicts
 

--- a/docker_challenges/assets/shared/modalUtils.js
+++ b/docker_challenges/assets/shared/modalUtils.js
@@ -1,0 +1,41 @@
+/**
+ * Vanilla JS modal helpers for Bootstrap CSS-based modals.
+ *
+ * CTFd does not expose `bootstrap` as a reliable global variable for plugins.
+ * These helpers toggle modal visibility via CSS classes, which works with both
+ * Bootstrap 4 and Bootstrap 5 stylesheets without requiring their JS bundles.
+ */
+
+export function showModal(modalEl) {
+    modalEl.classList.add('show');
+    modalEl.style.display = 'block';
+    modalEl.setAttribute('aria-modal', 'true');
+    modalEl.removeAttribute('aria-hidden');
+
+    let backdrop = document.querySelector('.modal-backdrop');
+    if (!backdrop) {
+        backdrop = document.createElement('div');
+        backdrop.className = 'modal-backdrop fade show';
+        document.body.appendChild(backdrop);
+    }
+
+    document.body.classList.add('modal-open');
+}
+
+export function hideModal(modalEl) {
+    modalEl.classList.remove('show');
+    modalEl.style.display = 'none';
+    modalEl.removeAttribute('aria-modal');
+    modalEl.setAttribute('aria-hidden', 'true');
+
+    const backdrop = document.querySelector('.modal-backdrop');
+    if (backdrop) backdrop.remove();
+
+    document.body.classList.remove('modal-open');
+}
+
+export function bindDismissButtons(modalEl) {
+    modalEl.querySelectorAll('[data-bs-dismiss="modal"], [data-dismiss="modal"]').forEach((btn) => {
+        btn.addEventListener('click', () => hideModal(modalEl));
+    });
+}

--- a/docker_challenges/assets/shared/secretManagement.js
+++ b/docker_challenges/assets/shared/secretManagement.js
@@ -11,6 +11,8 @@
  * Similar to portManagement.js pattern
  */
 
+import { showModal, hideModal, bindDismissButtons } from './modalUtils.js';
+
 /**
  * Fetch Docker images and populate dropdown with auto-port population.
  *
@@ -215,11 +217,12 @@ export function setupQuickSecretModal(addButtonId, modalId, formId, onSuccess) {
 
     // Add Secret button handler
     document.getElementById(addButtonId).addEventListener('click', function () {
-        const modal = new bootstrap.Modal(document.getElementById(modalId));
+        const modalEl = document.getElementById(modalId);
         document.getElementById(formId).reset();
         document.getElementById('quickSecretError').style.display = 'none';
         resetSubmitButton();
-        modal.show();
+        bindDismissButtons(modalEl);
+        showModal(modalEl);
     });
 
     // Submit Quick Secret
@@ -247,7 +250,7 @@ export function setupQuickSecretModal(addButtonId, modalId, formId, onSuccess) {
             .then((response) => response.json().then((data) => ({ status: response.status, data })))
             .then((result) => {
                 if (result.status === 201 && result.data.success) {
-                    bootstrap.Modal.getInstance(document.getElementById(modalId)).hide();
+                    hideModal(document.getElementById(modalId));
                     resetSubmitButton();
 
                     // Call success callback with new secret ID

--- a/docker_challenges/assets/view.js
+++ b/docker_challenges/assets/view.js
@@ -229,14 +229,14 @@ document.addEventListener('alpine:init', () => {
     }
 });
 
-// Check if Alpine.js and Bootstrap are available
-function hasAlpineAndBootstrap() {
-    return typeof Alpine !== 'undefined' && typeof bootstrap !== 'undefined' && bootstrap.Modal;
+// Check if Alpine.js is available
+function hasAlpine() {
+    return typeof Alpine !== 'undefined';
 }
 
 // Alert modal function (CTFd Pattern with Alpine.js)
 function ezal(args) {
-    if (!hasAlpineAndBootstrap()) {
+    if (!hasAlpine()) {
         // Fallback to native alert
         alert(args.title + '\n\n' + args.body);
         return;
@@ -249,10 +249,35 @@ function ezal(args) {
         button: args.button || 'Got it!',
     });
 
-    // Show modal using Bootstrap Modal API
+    // Show modal using vanilla JS (no bootstrap.Modal dependency)
     const modalElement = document.querySelector('[x-ref="alertModal"]');
-    const modal = new bootstrap.Modal(modalElement);
-    modal.show();
+    modalElement.classList.add('show');
+    modalElement.style.display = 'block';
+    modalElement.setAttribute('aria-modal', 'true');
+    modalElement.removeAttribute('aria-hidden');
+
+    var backdrop = document.querySelector('.modal-backdrop');
+    if (!backdrop) {
+        backdrop = document.createElement('div');
+        backdrop.className = 'modal-backdrop fade show';
+        document.body.appendChild(backdrop);
+    }
+    document.body.classList.add('modal-open');
+
+    // Bind dismiss buttons for close/cancel
+    modalElement
+        .querySelectorAll('[data-bs-dismiss="modal"], [data-dismiss="modal"]')
+        .forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                modalElement.classList.remove('show');
+                modalElement.style.display = 'none';
+                modalElement.removeAttribute('aria-modal');
+                modalElement.setAttribute('aria-hidden', 'true');
+                var bd = document.querySelector('.modal-backdrop');
+                if (bd) bd.remove();
+                document.body.classList.remove('modal-open');
+            });
+        });
 }
 
 // Expose containerStatus to global scope for Alpine.js x-data directives

--- a/docker_challenges/assets/view.js
+++ b/docker_challenges/assets/view.js
@@ -251,6 +251,11 @@ function ezal(args) {
 
     // Show modal using vanilla JS (no bootstrap.Modal dependency)
     const modalElement = document.querySelector('[x-ref="alertModal"]');
+    if (!modalElement) {
+        // Modal template not present (e.g., admin page context) — fall back to native alert
+        alert(args.title + '\n\n' + args.body);
+        return;
+    }
     modalElement.classList.add('show');
     modalElement.style.display = 'block';
     modalElement.setAttribute('aria-modal', 'true');

--- a/docker_challenges/templates/admin_docker_secrets.html
+++ b/docker_challenges/templates/admin_docker_secrets.html
@@ -167,7 +167,7 @@
                     <button
                         type="button"
                         class="btn btn-danger"
-                        @click="$store.confirmModal.onConfirm(); $refs.confirmModal.dispatchEvent(new Event('hide.bs.modal'))"
+                        @click="$store.confirmModal.onConfirm(); hideModal($refs.confirmModal)"
                     >
                         Yes
                     </button>
@@ -201,6 +201,41 @@
 </div>
 {% endblock content %} {% block scripts %}
 <script>
+    // Vanilla JS modal helpers (framework-agnostic, works with BS4/BS5 CSS)
+    function showModal(modalEl) {
+        modalEl.classList.add('show');
+        modalEl.style.display = 'block';
+        modalEl.setAttribute('aria-modal', 'true');
+        modalEl.removeAttribute('aria-hidden');
+        var backdrop = document.querySelector('.modal-backdrop');
+        if (!backdrop) {
+            backdrop = document.createElement('div');
+            backdrop.className = 'modal-backdrop fade show';
+            document.body.appendChild(backdrop);
+        }
+        document.body.classList.add('modal-open');
+    }
+
+    function hideModal(modalEl) {
+        modalEl.classList.remove('show');
+        modalEl.style.display = 'none';
+        modalEl.removeAttribute('aria-modal');
+        modalEl.setAttribute('aria-hidden', 'true');
+        var backdrop = document.querySelector('.modal-backdrop');
+        if (backdrop) backdrop.remove();
+        document.body.classList.remove('modal-open');
+    }
+
+    function bindDismissButtons(modalEl) {
+        modalEl
+            .querySelectorAll('[data-bs-dismiss="modal"], [data-dismiss="modal"]')
+            .forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    hideModal(modalEl);
+                });
+            });
+    }
+
     // Initialize Alpine.js stores
     if (typeof Alpine !== 'undefined') {
         Alpine.store('confirmModal', { title: '', body: '', onConfirm: () => {} });
@@ -209,7 +244,7 @@
 
     // Helper: Show confirmation modal
     function ezq(args) {
-        if (typeof Alpine === 'undefined' || typeof bootstrap === 'undefined') {
+        if (typeof Alpine === 'undefined') {
             if (confirm(args.title + '\n\n' + args.body)) args.success();
             return;
         }
@@ -218,12 +253,14 @@
             body: args.body,
             onConfirm: args.success,
         });
-        new bootstrap.Modal(document.querySelector('[x-ref="confirmModal"]')).show();
+        var modalEl = document.querySelector('[x-ref="confirmModal"]');
+        bindDismissButtons(modalEl);
+        showModal(modalEl);
     }
 
     // Helper: Show alert modal
     function ezal(args) {
-        if (typeof Alpine === 'undefined' || typeof bootstrap === 'undefined') {
+        if (typeof Alpine === 'undefined') {
             alert(args.title + '\n\n' + args.body);
             return;
         }
@@ -232,15 +269,18 @@
             body: args.body,
             button: args.button || 'Got it!',
         });
-        new bootstrap.Modal(document.querySelector('[x-ref="alertModal"]')).show();
+        var modalEl = document.querySelector('[x-ref="alertModal"]');
+        bindDismissButtons(modalEl);
+        showModal(modalEl);
     }
 
     // Create Secret Modal
     document.getElementById('create-secret-btn').addEventListener('click', function () {
-        const modal = new bootstrap.Modal(document.querySelector('[x-ref="createSecretModal"]'));
+        var modalEl = document.querySelector('[x-ref="createSecretModal"]');
         document.getElementById('createSecretForm').reset();
         document.getElementById('createSecretError').style.display = 'none';
-        modal.show();
+        bindDismissButtons(modalEl);
+        showModal(modalEl);
     });
 
     // Submit Create Secret
@@ -270,9 +310,7 @@
             .then((response) => response.json().then((data) => ({ status: response.status, data })))
             .then((result) => {
                 if (result.status === 201 && result.data.success) {
-                    bootstrap.Modal.getInstance(
-                        document.querySelector('[x-ref="createSecretModal"]')
-                    ).hide();
+                    hideModal(document.querySelector('[x-ref="createSecretModal"]'));
                     ezal({ title: 'Success', body: 'Secret created successfully!' });
                     setTimeout(() => window.location.reload(), 1500);
                 } else {

--- a/docker_challenges/templates/admin_docker_status.html
+++ b/docker_challenges/templates/admin_docker_status.html
@@ -106,7 +106,7 @@
                     <button
                         type="button"
                         class="btn btn-danger"
-                        @click="$store.confirmModal.onConfirm(); $refs.confirmModal.dispatchEvent(new Event('hide.bs.modal'))"
+                        @click="$store.confirmModal.onConfirm(); hideModal($refs.confirmModal)"
                     >
                         Yes
                     </button>
@@ -296,14 +296,49 @@
         }
     });
 
-    // Check if Alpine.js and Bootstrap are available
-    function hasAlpineAndBootstrap() {
-        return typeof Alpine !== 'undefined' && typeof bootstrap !== 'undefined' && bootstrap.Modal;
+    // Vanilla JS modal helpers (framework-agnostic, works with BS4/BS5 CSS)
+    function showModal(modalEl) {
+        modalEl.classList.add('show');
+        modalEl.style.display = 'block';
+        modalEl.setAttribute('aria-modal', 'true');
+        modalEl.removeAttribute('aria-hidden');
+        var backdrop = document.querySelector('.modal-backdrop');
+        if (!backdrop) {
+            backdrop = document.createElement('div');
+            backdrop.className = 'modal-backdrop fade show';
+            document.body.appendChild(backdrop);
+        }
+        document.body.classList.add('modal-open');
+    }
+
+    function hideModal(modalEl) {
+        modalEl.classList.remove('show');
+        modalEl.style.display = 'none';
+        modalEl.removeAttribute('aria-modal');
+        modalEl.setAttribute('aria-hidden', 'true');
+        var backdrop = document.querySelector('.modal-backdrop');
+        if (backdrop) backdrop.remove();
+        document.body.classList.remove('modal-open');
+    }
+
+    function bindDismissButtons(modalEl) {
+        modalEl
+            .querySelectorAll('[data-bs-dismiss="modal"], [data-dismiss="modal"]')
+            .forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    hideModal(modalEl);
+                });
+            });
+    }
+
+    // Check if Alpine.js is available
+    function hasAlpine() {
+        return typeof Alpine !== 'undefined';
     }
 
     // Confirmation modal function (CTFd Pattern with Alpine.js)
     function ezq(args) {
-        if (!hasAlpineAndBootstrap()) {
+        if (!hasAlpine()) {
             // Fallback to native confirm
             if (confirm(args.title + '\n\n' + args.body)) {
                 args.success();
@@ -318,15 +353,15 @@
             onConfirm: args.success,
         });
 
-        // Show modal using Bootstrap Modal API
+        // Show modal using vanilla JS
         const modalElement = document.querySelector('[x-ref="confirmModal"]');
-        const modal = new bootstrap.Modal(modalElement);
-        modal.show();
+        bindDismissButtons(modalElement);
+        showModal(modalElement);
     }
 
     // Alert modal function (CTFd Pattern with Alpine.js)
     function ezal(args) {
-        if (!hasAlpineAndBootstrap()) {
+        if (!hasAlpine()) {
             // Fallback to native alert
             alert(args.title + '\n\n' + args.body);
             return;
@@ -339,10 +374,10 @@
             button: args.button || 'Got it!',
         });
 
-        // Show modal using Bootstrap Modal API
+        // Show modal using vanilla JS
         const modalElement = document.querySelector('[x-ref="alertModal"]');
-        const modal = new bootstrap.Modal(modalElement);
-        modal.show();
+        bindDismissButtons(modalElement);
+        showModal(modalElement);
     }
 </script>
 {% endblock scripts %}


### PR DESCRIPTION
## Summary

- Fixes `Uncaught ReferenceError: bootstrap is not defined` when clicking "Add Secret" on `/challenges/new` and `/admin/docker_secrets`, and when using confirm/alert modals on `/admin/docker_status`
- Replaces all `bootstrap.Modal` API calls with vanilla JS that toggles modal visibility via CSS classes (`show` class, `display: block`, backdrop div, `modal-open` on body)
- Adds shared `modalUtils.js` helper for ES module contexts; inline equivalents for template `<script>` blocks

## Changed Files

| File | Change |
|------|--------|
| `assets/shared/modalUtils.js` | **New** — shared `showModal()`, `hideModal()`, `bindDismissButtons()` |
| `assets/shared/secretManagement.js` | Import modalUtils; replace `bootstrap.Modal` calls |
| `templates/admin_docker_secrets.html` | Inline vanilla modal helpers; remove bootstrap guard |
| `templates/admin_docker_status.html` | Same pattern; rename `hasAlpineAndBootstrap` → `hasAlpine` |
| `assets/view.js` | Inline vanilla modal show/dismiss; rename availability check |
| `agent-docs/architecture/limitations.md` | Document Bootstrap JS API limitation and workaround |

## Test plan

- [x] `pre-commit run --all-files` passes (prettier, ruff-format, bandit, etc.)
- [x] Navigate to `/admin/challenges/new`, select "docker_service" type → click "Add Secret" → modal opens without console errors
- [x] Fill quick secret form, click "Create & Select" → modal closes, secret appears in dropdown
- [x] Cancel button and X close button both dismiss modal correctly
- [x] Navigate to `/admin/docker_secrets` → click "Create Secret" → modal opens and submits
- [x] Delete individual secret → confirmation modal works
- [x] Navigate to `/admin/docker_status` → nuke container → confirmation modal works
- [x] Check browser console for zero `bootstrap is not defined` errors across all pages