### PR TITLE
bump: version 3.1.1 → 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [unreleased]: https://github.com/shiftysheep/CTFd-Docker-Challenges/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/shiftysheep/CTFd-Docker-Challenges/releases/tag/v1.0.0
 
+## v3.1.2 (2026-02-17)
+
+### Fix
+
+- **frontend**: replace bootstrap.Modal with vanilla JS helpers (#14)
+- **tls**: prevent cert file deletion on config form resubmission (#12)
+
 ## v3.1.1 (2026-02-12)
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plugin for CTFd allows competing teams/users to start dockerized images for
 
 > **For Contributors**: See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code quality standards, and contribution guidelines.
 
-## Version 3.1.1
+## Version 3.1.2
 
 **Latest Update**: Migrated to Alpine.js and Bootstrap 5 for CTFd 3.8.0+ (core theme)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctfd-docker-challenges"
-version = "3.1.1"
+version = "3.1.2"
 description = "Docker-based challenge support for CTFd"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -396,7 +396,7 @@ toml = [
 
 [[package]]
 name = "ctfd-docker-challenges"
-version = "3.1.1"
+version = "3.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
## Summary

- Bump version `3.1.1` → `3.1.2` (patch release)
- Updates `pyproject.toml`, `README.md`, `CHANGELOG.md`, `uv.lock`
- Tag `v3.1.2` created by commitizen

## Changelog

### Fix

- **frontend**: handle nested form stripping and missing modal elements
- **frontend**: replace bootstrap.Modal with vanilla JS helpers

## Test plan

- [ ] Version in `pyproject.toml` reads `3.1.2`
- [ ] `README.md` header reads `## Version 3.1.2`
- [ ] `CHANGELOG.md` has `## v3.1.2` section