### PR TITLE
fix(frontend): resolve nested form breaking service challenge update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,13 @@ Before submitting a PR, test the following scenarios:
 - [ ] Verify container cleanup on challenge solve
 - [ ] Verify 2-hour stale container cleanup
 
+#### Challenge Update
+
+- [ ] Update `docker` challenge (change name, value, state) and verify success toast
+- [ ] Update `docker_service` challenge and verify success toast
+- [ ] Quick secret modal opens, validates, and creates secret from update page
+- [ ] Quick secret modal opens, validates, and creates secret from create page
+
 #### Admin Functions
 
 - [ ] Docker config page saves settings correctly

--- a/agent-docs/architecture/limitations.md
+++ b/agent-docs/architecture/limitations.md
@@ -47,6 +47,13 @@ This is a **LIVING DOCUMENT**. Agents working in this codebase should add discov
 - **Workaround**: Use vanilla JS modal toggling (CSS class manipulation) instead of `bootstrap.Modal` API. Shared helper in `assets/shared/modalUtils.js` exports `showModal()`, `hideModal()`, and `bindDismissButtons()`. Inline scripts in templates define equivalent functions locally (can't import ES modules in inline scripts).
 - **Reference**: `assets/shared/modalUtils.js`, `templates/admin_docker_secrets.html`, `templates/admin_docker_status.html`, `assets/view.js`
 
+### CTFd Outer Form - Nested `<form>` Tags Break Submit Handling
+
+- **Issue**: CTFd's admin challenge templates (`admin/challenges/update.html`, `admin/challenges/create.html`) wrap all `{% block %}` content inside a single `<form method="POST">`. HTML forbids nested forms — browsers silently drop the inner `<form>` start tag but the inner `</form>` closes the _outer_ form. This causes any elements after the inner `</form>` (e.g., the Update button) to fall outside the form, breaking CTFd's jQuery submit handler (`$("#challenge-update-container > form").submit()`).
+- **Impact**: Challenge update/create buttons silently fail with no error when a nested `<form>` is present in the template
+- **Workaround**: Use `<div>` instead of `<form>` for any container inside `{% block category %}` or other template blocks. Use explicit JS validation instead of HTML `required` attributes on inputs inside modals (hidden `required` inputs inside the outer form cause "not focusable" browser validation errors on submit).
+- **Reference**: `assets/create_service.html`, `assets/update_service.html`, `assets/shared/secretManagement.js`
+
 ### Dynamic Form Loading - DOMContentLoaded Conflicts
 
 - **Issue**: Challenge forms load dynamically via AJAX, not on initial page load. `DOMContentLoaded` event wrappers prevent API calls because DOM already loaded when scripts execute.

--- a/agent-docs/architecture/patterns.md
+++ b/agent-docs/architecture/patterns.md
@@ -193,4 +193,4 @@ tracker = DockerChallengeTracker.query.filter_by(
 4. Audit logging (username + resource name, never values)
 5. TOCTOU awareness (Docker API as authoritative duplicate check)
 
-**Frontend**: Alpine.js modal with Bootstrap, bulk operations with confirmation dialog
+**Frontend**: Vanilla JS modals (CSS class manipulation via `modalUtils.js`), bulk operations with confirmation dialog. Avoid `<form>` tags inside modals rendered within CTFd's admin templates (see `limitations.md` - nested form issue).

--- a/docker_challenges/assets/create_service.html
+++ b/docker_challenges/assets/create_service.html
@@ -87,7 +87,7 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
-                <form id="quickSecretForm">
+                <div id="quickSecretForm">
                     <div class="mb-3">
                         <label for="quickSecretName" class="form-label">Secret Name</label>
                         <input
@@ -95,7 +95,6 @@
                             class="form-control"
                             id="quickSecretName"
                             pattern="[a-zA-Z0-9._-]+"
-                            required
                         />
                         <small class="text-muted"
                             >Letters, numbers, dots, underscores, hyphens only</small
@@ -103,19 +102,14 @@
                     </div>
                     <div class="mb-3">
                         <label for="quickSecretValue" class="form-label">Secret Value</label>
-                        <textarea
-                            class="form-control"
-                            id="quickSecretValue"
-                            rows="3"
-                            required
-                        ></textarea>
+                        <textarea class="form-control" id="quickSecretValue" rows="3"></textarea>
                     </div>
                     <div
                         id="quickSecretError"
                         class="alert alert-danger"
                         style="display: none"
                     ></div>
-                </form>
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">

--- a/docker_challenges/assets/shared/secretManagement.js
+++ b/docker_challenges/assets/shared/secretManagement.js
@@ -215,22 +215,16 @@ export function setupQuickSecretModal(addButtonId, modalId, formId, onSuccess) {
         submitBtn.innerHTML = 'Create & Select';
     }
 
-    // Note: CTFd loads challenge forms inside a parent <form>, so the nested
-    // <form id="quickSecretForm"> gets stripped by the browser (invalid HTML).
-    // We fall back to the modal element for reset/validation when this happens.
-    function getFormOrModal() {
+    // The quickSecretForm container is a <div> (not a <form>) to avoid nested
+    // form issues — CTFd wraps the challenge update template in its own <form>.
+    // We use the container to scope input queries for reset/validation.
+    function getFormContainer() {
         return document.getElementById(formId) || document.getElementById(modalId);
     }
 
     function resetFormFields() {
-        const form = document.getElementById(formId);
-        if (form) {
-            form.reset();
-            return;
-        }
-        // Fallback: reset inputs manually when <form> was stripped
-        const modal = document.getElementById(modalId);
-        modal.querySelectorAll('input, textarea').forEach((el) => {
+        const container = getFormContainer();
+        container.querySelectorAll('input, textarea').forEach((el) => {
             if (el.type === 'checkbox' || el.type === 'radio') {
                 el.checked = el.defaultChecked;
             } else {
@@ -240,22 +234,26 @@ export function setupQuickSecretModal(addButtonId, modalId, formId, onSuccess) {
     }
 
     function validateFields() {
-        const form = document.getElementById(formId);
-        if (form) {
-            if (!form.checkValidity()) {
-                form.reportValidity();
-                return false;
-            }
-            return true;
+        const name = document.getElementById('quickSecretName');
+        const value = document.getElementById('quickSecretValue');
+        if (!name.value.trim()) {
+            name.focus();
+            document.getElementById('quickSecretError').textContent = 'Secret name is required';
+            document.getElementById('quickSecretError').style.display = 'block';
+            return false;
         }
-        // Fallback: validate required inputs manually
-        const modal = document.getElementById(modalId);
-        const inputs = modal.querySelectorAll('input[required], textarea[required]');
-        for (const input of inputs) {
-            if (!input.checkValidity()) {
-                input.reportValidity();
-                return false;
-            }
+        if (!name.checkValidity()) {
+            name.focus();
+            document.getElementById('quickSecretError').textContent =
+                'Secret name may only contain letters, numbers, dots, underscores, and hyphens';
+            document.getElementById('quickSecretError').style.display = 'block';
+            return false;
+        }
+        if (!value.value.trim()) {
+            value.focus();
+            document.getElementById('quickSecretError').textContent = 'Secret value is required';
+            document.getElementById('quickSecretError').style.display = 'block';
+            return false;
         }
         return true;
     }

--- a/docker_challenges/assets/update_service.html
+++ b/docker_challenges/assets/update_service.html
@@ -100,7 +100,7 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
-                <form id="quickSecretForm">
+                <div id="quickSecretForm">
                     <div class="mb-3">
                         <label for="quickSecretName" class="form-label">Secret Name</label>
                         <input
@@ -108,7 +108,6 @@
                             class="form-control"
                             id="quickSecretName"
                             pattern="[a-zA-Z0-9._-]+"
-                            required
                         />
                         <small class="text-muted"
                             >Letters, numbers, dots, underscores, hyphens only</small
@@ -116,19 +115,14 @@
                     </div>
                     <div class="mb-3">
                         <label for="quickSecretValue" class="form-label">Secret Value</label>
-                        <textarea
-                            class="form-control"
-                            id="quickSecretValue"
-                            rows="3"
-                            required
-                        ></textarea>
+                        <textarea class="form-control" id="quickSecretValue" rows="3"></textarea>
                     </div>
                     <div
                         id="quickSecretError"
                         class="alert alert-danger"
                         style="display: none"
                     ></div>
-                </form>
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">


### PR DESCRIPTION
## Summary

- Fix docker_service challenge update/create forms silently failing due to nested `<form>` tags inside CTFd's outer form
- The quick-secret modal's `<form id="quickSecretForm">` caused the browser to close CTFd's outer form early, leaving the Update button outside any form element
- CTFd's jQuery submit handler never fired, silently preventing challenge saves with no error

## Changes

- **`create_service.html` / `update_service.html`**: Changed `<form id="quickSecretForm">` to `<div>`, removed `required` attributes from modal inputs
- **`secretManagement.js`**: Rewrote validation to use explicit JS checks with inline error display instead of browser-native form validation
- **`limitations.md`**: Documented the nested form limitation and workaround pattern
- **`patterns.md`**: Updated modal description from Bootstrap to vanilla JS
- **`CONTRIBUTING.md`**: Added challenge update testing steps to manual checklist

## Test plan

- [x] Create docker_service challenge — form submits, options dialog appears
- [x] Update docker_service challenge — "Your challenge has been updated!" success toast
- [x] Quick secret modal validation works (empty name/value shows inline errors)
- [x] All 188 unit tests pass
- [x] Pre-commit hooks pass