### PR TITLE
fix(frontend): resolve Docker challenge modal not reopenable after close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [unreleased]: https://github.com/shiftysheep/CTFd-Docker-Challenges/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/shiftysheep/CTFd-Docker-Challenges/releases/tag/v1.0.0
 
+## v3.1.4 (2026-02-17)
+
+### Fix
+
+- **frontend**: use var for re-evaluable top-level declarations in view.js
+- **frontend**: clean up Alpine.js timers on modal close
+
 ## v3.1.3 (2026-02-17)
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plugin for CTFd allows competing teams/users to start dockerized images for
 
 > **For Contributors**: See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code quality standards, and contribution guidelines.
 
-## Version 3.1.3
+## Version 3.1.4
 
 **Latest Update**: Migrated to Alpine.js and Bootstrap 5 for CTFd 3.8.0+ (core theme)
 

--- a/agent-docs/development/building.md
+++ b/agent-docs/development/building.md
@@ -29,14 +29,16 @@ This document covers ONLY non-standard build aspects. For complete build procedu
 
 ## Version Bumping
 
-**Always bump the version after merging a PR.** Use Commitizen to auto-detect the increment:
+**Bump the version on the feature branch before merging the PR.** This keeps the bump commit in the same PR and reduces commit noise on `master`. Use Commitizen to auto-detect the increment:
 
 ```bash
-cz bump          # Auto-detects patch/minor/major from commits
 cz bump --dry-run  # Preview before running
+cz bump            # Auto-detects patch/minor/major from commits
 ```
 
-Commitizen updates `pyproject.toml`, `README.md`, and `CHANGELOG.md`, creates a commit, and tags it. Push the bump as a separate PR and then push the tag after merge:
+Commitizen updates `pyproject.toml`, `README.md`, and `CHANGELOG.md`, creates a commit, and tags it.
+
+After merging, retag the squash-merged commit and push the tag:
 
 ```bash
 git tag -d vX.Y.Z                    # Delete local tag (points to pre-squash commit)

--- a/docker_challenges/assets/view.js
+++ b/docker_challenges/assets/view.js
@@ -1,9 +1,10 @@
 // Inline constants (cannot use ES6 imports due to Alpine.js race condition)
 // See CLAUDE.md for explanation of why ES6 modules don't work for challenge views
-const CONTAINER_POLL_INTERVAL_MS = 30000; // 30 seconds (base interval)
-const CONTAINER_POLL_MAX_INTERVAL_MS = 300000; // 5 minutes (max backoff)
-const CONTAINER_POLL_BACKOFF_MULTIPLIER = 2; // Double interval on each failure
-const MS_PER_SECOND = 1000;
+// Using var so the script can be re-evaluated when switching between Docker challenges
+var CONTAINER_POLL_INTERVAL_MS = 30000; // 30 seconds (base interval)
+var CONTAINER_POLL_MAX_INTERVAL_MS = 300000; // 5 minutes (max backoff)
+var CONTAINER_POLL_BACKOFF_MULTIPLIER = 2; // Double interval on each failure
+var MS_PER_SECOND = 1000;
 
 CTFd._internal.challenge.data = undefined;
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctfd-docker-challenges"
-version = "3.1.3"
+version = "3.1.4"
 description = "Docker-based challenge support for CTFd"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -396,7 +396,7 @@ toml = [
 
 [[package]]
 name = "ctfd-docker-challenges"
-version = "3.1.3"
+version = "3.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
## Summary

- Fix Docker challenge modals being unopenable after closing — top-level `const` declarations in `view.js` throw `SyntaxError` when CTFd re-evaluates the script for a second challenge in the same global scope; changed to `var`
- Add Alpine.js `destroy()` lifecycle and `hidden.bs.modal` listener to clean up orphaned poll/countdown timers when the modal closes
- Bump version 3.1.3 → 3.1.4
- Update version bump docs to reflect bump-before-merge workflow

## Test plan

- [x] Open Docker challenge A → close modal → open Docker challenge B (verified with Playwright, zero console errors)
- [x] Open A → close → B → close → A round-trip works
- [x] `pre-commit run --all-files` passes
- [x] `pytest tests/` — 188 tests pass
- [ ] Verify in browser: Network tab shows no stale API polling after modal close