### PR TITLE
feat(frontend): add copyable connection URLs to challenge view

### DIFF
--- a/agent-docs/architecture/limitations.md
+++ b/agent-docs/architecture/limitations.md
@@ -115,6 +115,13 @@ This is a **LIVING DOCUMENT**. Agents working in this codebase should add discov
 - **Workaround**: Follow manual testing checklist in CONTRIBUTING.md before PRs
 - **Reference**: `CONTRIBUTING.md` - "Manual Testing" section, `CLAUDE.md` - "Outstanding Issues"
 
+### Docker API - Port Format Variation
+
+- **Issue**: Docker API returns ports in different formats depending on daemon configuration. Backend code in `api/api.py` (lines 130-137) constructs port strings but actual format varies: container format (`hostPort->targetPort/protocol`), service format (`hostPort/protocol-> targetPort`), or both-sided format (`hostPort/protocol->targetPort/protocol`). The both-sided format was discovered during Playwright testing against Docker-in-Docker environment—not evident from static code analysis.
+- **Impact**: Frontend `parsePort()` function in `view.js` must handle all three formats to parse ports reliably
+- **Workaround**: Frontend parsing implemented with three-format support; discovered through live integration testing
+- **Reference**: `api/api.py:130-137`, `assets/view.js:parsePort()`, Playwright tests against docker-compose environment
+
 ---
 
 ## Deployment

--- a/agent-docs/development/testing.md
+++ b/agent-docs/development/testing.md
@@ -19,3 +19,4 @@ This document covers ONLY non-standard testing aspects. For complete testing pro
 
 - `docker compose up` starts full stack for manual testing
 - CTFd accessible at `http://localhost` (port 80 via nginx)
+- Playwright tests against Docker Compose catch format discrepancies (e.g., port string variations) that static code analysis cannot detect—Docker daemon behavior differs from code reading

--- a/docker_challenges/assets/view.html
+++ b/docker_challenges/assets/view.html
@@ -14,7 +14,69 @@
 
     <!-- Connection information - shown when container is running -->
     <div x-show="containerRunning">
-        <pre x-text="getConnectionInfo()"></pre>
+        <div
+            style="
+                background: #1e1e2e;
+                border-radius: 8px;
+                padding: 16px;
+                text-align: left;
+                font-family: 'Courier New', monospace;
+                font-size: 14px;
+                color: #cdd6f4;
+            "
+        >
+            <div style="margin-bottom: 12px; font-weight: bold; color: #a6adc8">
+                Docker Container Information:
+            </div>
+            <template x-for="(port, index) in getParsedPorts()" :key="index">
+                <div
+                    style="
+                        display: flex;
+                        align-items: center;
+                        padding: 6px 0;
+                        border-bottom: 1px solid #313244;
+                        gap: 8px;
+                    "
+                >
+                    <template x-if="port.isLink">
+                        <a
+                            :href="port.connectionUrl"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style="color: #89b4fa; text-decoration: underline"
+                            x-text="port.connectionUrl"
+                        ></a>
+                    </template>
+                    <template x-if="!port.isLink">
+                        <span x-text="port.connectionUrl"></span>
+                    </template>
+                    <span x-text="port.targetLabel" style="color: #6c7086; font-size: 12px"></span>
+                    <button
+                        @click="copyConnectionUrl(index, port)"
+                        style="
+                            margin-left: auto;
+                            background: #313244;
+                            border: 1px solid #45475a;
+                            border-radius: 4px;
+                            color: #cdd6f4;
+                            padding: 4px 10px;
+                            cursor: pointer;
+                            font-size: 12px;
+                            display: flex;
+                            align-items: center;
+                            gap: 4px;
+                        "
+                    >
+                        <template x-if="copiedIndex !== index">
+                            <span><i class="fas fa-copy"></i> Copy</span>
+                        </template>
+                        <template x-if="copiedIndex === index">
+                            <span style="color: #a6e3a1"><i class="fas fa-check"></i> Copied!</span>
+                        </template>
+                    </button>
+                </div>
+            </template>
+        </div>
         <div class="mt-2">
             <span x-text="countdownText"></span>
             <!-- Revert button appears when countdown expires -->


### PR DESCRIPTION
## Summary

- Replace plain-text `<pre>` connection info with structured per-port rows in a dark terminal-style container
- Add smart URL formatting: HTTP/HTTPS links for web ports (80, 443, 3000, 5000, 8000, 8080, 8443, 8888, 9000), plain `host:port` for everything else
- Add per-port copy-to-clipboard buttons with 1.5s "Copied!" feedback
- Parse all three backend port string formats: container (`58438->80/tcp`), service (`58438/tcp-> 80`), and both-sided (`58438/tcp->80/tcp`)

## Test plan

- [x] `pre-commit run --all-files` passes (prettier, bandit, etc.)
- [x] Started container challenge in Docker Compose test environment
- [x] Verified both-sided port format `58438/tcp->80/tcp` parses correctly
- [x] Verified web port (target 80) renders as clickable HTTP link
- [x] Verified Copy button copies URL and shows "Copied!" feedback (reverts after 1.5s)
- [x] Verified zero console errors
- [ ] Manual test with service challenge (service port format)
- [ ] Manual test with multi-port challenge
- [ ] Manual test with non-web port (e.g., SSH on port 22)