### PR TITLE
docs(agent-docs): add Playwright testing and cleanup requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 __pycache__/
 .vscode
 .coverage
+test-artifacts/

--- a/agent-docs/development/testing.md
+++ b/agent-docs/development/testing.md
@@ -20,3 +20,29 @@ This document covers ONLY non-standard testing aspects. For complete testing pro
 - `docker compose up` starts full stack for manual testing
 - CTFd accessible at `http://localhost` (port 80 via nginx)
 - Playwright tests against Docker Compose catch format discrepancies (e.g., port string variations) that static code analysis cannot detect—Docker daemon behavior differs from code reading
+
+## Playwright Testing (Browser Automation)
+
+**Purpose**: Catch runtime discrepancies that static analysis misses (e.g., Docker API port format variations, UI rendering issues). The copyable connection URLs feature exposed a port format bug only visible when running against a live Docker daemon.
+
+**Prerequisites**: Docker Compose environment running (`docker compose -f docker-compose.test.yml up`)
+
+**Artifact Directory**: All screenshots and test outputs go in `test-artifacts/` (gitignored). Configure Playwright MCP screenshot filenames to use this directory (e.g., `test-artifacts/challenge-view.png`).
+
+### Testing Workflow
+
+1. Start Docker Compose environment (`docker compose -f docker-compose.test.yml up`)
+2. Run Playwright tests — navigate, interact, take screenshots to `test-artifacts/`
+3. Use descriptive screenshot filenames (e.g., `test-artifacts/challenge-ports-verified.png`)
+4. Check browser console for errors (`browser_console_messages`)
+5. Restart CTFd if Python changes were made (`docker compose restart ctfd` + hard browser refresh)
+
+### Cleanup Requirements
+
+After every Playwright session, before committing:
+
+1. Remove `test-artifacts/` contents: `rm -rf test-artifacts/*`
+2. Remove Playwright MCP state: `rm -rf .playwright-mcp/`
+3. Verify clean working tree: `git status` should show no untracked `.png`, `.jpeg`, or `.playwright-mcp/` files
+
+**Why this matters**: Screenshot files and `.playwright-mcp/` directories left behind will show as untracked files and risk accidental commits.


### PR DESCRIPTION
## Summary
- Added `test-artifacts/` to `.gitignore` as standard directory for temporary test outputs
- Added Playwright testing section to `agent-docs/development/testing.md` covering browser automation procedures, artifact management, and cleanup requirements
- Documents lessons learned from copyable connection URLs feature where Playwright caught a port format bug that static analysis missed

## Test plan
- [x] `test-artifacts/` appears in `.gitignore`
- [x] `agent-docs/development/testing.md` has Playwright and cleanup sections
- [x] `pre-commit run --all-files` passes (for changed files)