### PR TITLE
fix: container creation errors and nuke button not working

### DIFF
--- a/docker_challenges/functions/containers.py
+++ b/docker_challenges/functions/containers.py
@@ -58,7 +58,7 @@ def create_container(
     team: str,
     portbl: list[int],
     exposed_ports: str | None = None,
-) -> tuple[str, str]:
+) -> tuple[str, str] | tuple[None, None]:
     """
     Create a standalone Docker container for a challenge instance.
 
@@ -104,6 +104,8 @@ def create_container(
         method="POST",
         data=data,
     )
+    if not r:
+        return None, None
     instance_id = find_existing(docker, container_name) if r.status_code == 409 else r.json()["Id"]
 
     do_request(docker, url=f"/containers/{instance_id}/start", method="POST")

--- a/docker_challenges/templates/admin_docker_secrets.html
+++ b/docker_challenges/templates/admin_docker_secrets.html
@@ -90,111 +90,99 @@
     </div>
 </div>
 
-<!-- Modals (Alpine.js pattern from admin_docker_status.html) -->
-<div x-data>
-    <!-- Create Secret Modal -->
-    <div class="modal fade" x-ref="createSecretModal" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Create New Secret</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <form id="createSecretForm">
-                        <div class="mb-3">
-                            <label for="secretName" class="form-label">Secret Name</label>
-                            <input
-                                type="text"
-                                class="form-control"
-                                id="secretName"
-                                name="name"
-                                pattern="[a-zA-Z0-9._-]+"
-                                required
-                                placeholder="my_secret_name"
-                            />
-                            <small class="text-muted"
-                                >Only letters, numbers, dots, underscores, and hyphens</small
-                            >
-                        </div>
-                        <div class="mb-3">
-                            <label for="secretValue" class="form-label">Secret Value</label>
-                            <textarea
-                                class="form-control"
-                                id="secretValue"
-                                name="data"
-                                rows="4"
-                                required
-                            ></textarea>
-                            <small class="text-muted"
-                                >Value will be base64-encoded automatically</small
-                            >
-                        </div>
-                        <div
-                            id="createSecretError"
-                            class="alert alert-danger"
-                            style="display: none"
-                        ></div>
-                    </form>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                        Cancel
-                    </button>
-                    <button type="button" class="btn btn-success" id="submitCreateSecret">
-                        <i class="fas fa-plus"></i> Create Secret
-                    </button>
-                </div>
+<!-- Modal Templates (vanilla JS - no Alpine.js dependency) -->
+<!-- Create Secret Modal -->
+<div class="modal fade" id="createSecretModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Create New Secret</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="createSecretForm">
+                    <div class="mb-3">
+                        <label for="secretName" class="form-label">Secret Name</label>
+                        <input
+                            type="text"
+                            class="form-control"
+                            id="secretName"
+                            name="name"
+                            pattern="[a-zA-Z0-9._-]+"
+                            required
+                            placeholder="my_secret_name"
+                        />
+                        <small class="text-muted"
+                            >Only letters, numbers, dots, underscores, and hyphens</small
+                        >
+                    </div>
+                    <div class="mb-3">
+                        <label for="secretValue" class="form-label">Secret Value</label>
+                        <textarea
+                            class="form-control"
+                            id="secretValue"
+                            name="data"
+                            rows="4"
+                            required
+                        ></textarea>
+                        <small class="text-muted">Value will be base64-encoded automatically</small>
+                    </div>
+                    <div
+                        id="createSecretError"
+                        class="alert alert-danger"
+                        style="display: none"
+                    ></div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                    Cancel
+                </button>
+                <button type="button" class="btn btn-success" id="submitCreateSecret">
+                    <i class="fas fa-plus"></i> Create Secret
+                </button>
             </div>
         </div>
     </div>
+</div>
 
-    <!-- Confirmation Modal -->
-    <div class="modal fade" x-ref="confirmModal" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" x-text="$store.confirmModal.title"></h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <p x-text="$store.confirmModal.body"></p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                        No
-                    </button>
-                    <button
-                        type="button"
-                        class="btn btn-danger"
-                        @click="$store.confirmModal.onConfirm(); hideModal($refs.confirmModal)"
-                    >
-                        Yes
-                    </button>
-                </div>
+<!-- Confirmation Modal -->
+<div class="modal fade" id="confirmModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="confirmModalTitle"></h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p id="confirmModalBody"></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No</button>
+                <button type="button" class="btn btn-danger" id="confirmModalYes">Yes</button>
             </div>
         </div>
     </div>
+</div>
 
-    <!-- Alert Modal -->
-    <div class="modal fade" x-ref="alertModal" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" x-text="$store.alertModal.title"></h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <p x-text="$store.alertModal.body"></p>
-                </div>
-                <div class="modal-footer">
-                    <button
-                        type="button"
-                        class="btn btn-primary"
-                        data-bs-dismiss="modal"
-                        x-text="$store.alertModal.button"
-                    ></button>
-                </div>
+<!-- Alert Modal -->
+<div class="modal fade" id="alertModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="alertModalTitle"></h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p id="alertModalBody"></p>
+            </div>
+            <div class="modal-footer">
+                <button
+                    type="button"
+                    class="btn btn-primary"
+                    data-bs-dismiss="modal"
+                    id="alertModalButton"
+                ></button>
             </div>
         </div>
     </div>
@@ -236,47 +224,39 @@
             });
     }
 
-    // Initialize Alpine.js stores
-    if (typeof Alpine !== 'undefined') {
-        Alpine.store('confirmModal', { title: '', body: '', onConfirm: () => {} });
-        Alpine.store('alertModal', { title: '', body: '', button: 'Got it!' });
-    }
-
-    // Helper: Show confirmation modal
+    // Confirmation modal function (vanilla JS)
     function ezq(args) {
-        if (typeof Alpine === 'undefined') {
-            if (confirm(args.title + '\n\n' + args.body)) args.success();
-            return;
-        }
-        Alpine.store('confirmModal', {
-            title: args.title,
-            body: args.body,
-            onConfirm: args.success,
+        var modalEl = document.getElementById('confirmModal');
+        document.getElementById('confirmModalTitle').textContent = args.title;
+        document.getElementById('confirmModalBody').textContent = args.body;
+
+        // Replace Yes button to clear previous listeners
+        var oldBtn = document.getElementById('confirmModalYes');
+        var newBtn = oldBtn.cloneNode(true);
+        oldBtn.parentNode.replaceChild(newBtn, oldBtn);
+        newBtn.addEventListener('click', function () {
+            args.success();
+            hideModal(modalEl);
         });
-        var modalEl = document.querySelector('[x-ref="confirmModal"]');
+
         bindDismissButtons(modalEl);
         showModal(modalEl);
     }
 
-    // Helper: Show alert modal
+    // Alert modal function (vanilla JS)
     function ezal(args) {
-        if (typeof Alpine === 'undefined') {
-            alert(args.title + '\n\n' + args.body);
-            return;
-        }
-        Alpine.store('alertModal', {
-            title: args.title,
-            body: args.body,
-            button: args.button || 'Got it!',
-        });
-        var modalEl = document.querySelector('[x-ref="alertModal"]');
+        var modalEl = document.getElementById('alertModal');
+        document.getElementById('alertModalTitle').textContent = args.title;
+        document.getElementById('alertModalBody').textContent = args.body;
+        document.getElementById('alertModalButton').textContent = args.button || 'Got it!';
+
         bindDismissButtons(modalEl);
         showModal(modalEl);
     }
 
     // Create Secret Modal
     document.getElementById('create-secret-btn').addEventListener('click', function () {
-        var modalEl = document.querySelector('[x-ref="createSecretModal"]');
+        var modalEl = document.getElementById('createSecretModal');
         document.getElementById('createSecretForm').reset();
         document.getElementById('createSecretError').style.display = 'none';
         bindDismissButtons(modalEl);
@@ -310,7 +290,7 @@
             .then((response) => response.json().then((data) => ({ status: response.status, data })))
             .then((result) => {
                 if (result.status === 201 && result.data.success) {
-                    hideModal(document.querySelector('[x-ref="createSecretModal"]'));
+                    hideModal(document.getElementById('createSecretModal'));
                     ezal({ title: 'Success', body: 'Secret created successfully!' });
                     setTimeout(() => window.location.reload(), 1500);
                 } else {

--- a/docker_challenges/templates/admin_docker_status.html
+++ b/docker_challenges/templates/admin_docker_status.html
@@ -81,64 +81,54 @@
     </div>
 </div>
 
-<!-- Alpine.js Modal Templates (CTFd Pattern) -->
-<div x-data>
-    <!-- Confirmation Modal -->
-    <div class="modal fade" x-ref="confirmModal" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" x-text="$store.confirmModal.title"></h5>
-                    <button
-                        type="button"
-                        class="btn-close"
-                        data-bs-dismiss="modal"
-                        aria-label="Close"
-                    ></button>
-                </div>
-                <div class="modal-body">
-                    <p x-text="$store.confirmModal.body"></p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                        No
-                    </button>
-                    <button
-                        type="button"
-                        class="btn btn-danger"
-                        @click="$store.confirmModal.onConfirm(); hideModal($refs.confirmModal)"
-                    >
-                        Yes
-                    </button>
-                </div>
+<!-- Modal Templates (vanilla JS - no Alpine.js dependency) -->
+<!-- Confirmation Modal -->
+<div class="modal fade" id="confirmModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="confirmModalTitle"></h5>
+                <button
+                    type="button"
+                    class="btn-close"
+                    data-bs-dismiss="modal"
+                    aria-label="Close"
+                ></button>
+            </div>
+            <div class="modal-body">
+                <p id="confirmModalBody"></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No</button>
+                <button type="button" class="btn btn-danger" id="confirmModalYes">Yes</button>
             </div>
         </div>
     </div>
+</div>
 
-    <!-- Alert Modal -->
-    <div class="modal fade" x-ref="alertModal" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" x-text="$store.alertModal.title"></h5>
-                    <button
-                        type="button"
-                        class="btn-close"
-                        data-bs-dismiss="modal"
-                        aria-label="Close"
-                    ></button>
-                </div>
-                <div class="modal-body">
-                    <p x-text="$store.alertModal.body"></p>
-                </div>
-                <div class="modal-footer">
-                    <button
-                        type="button"
-                        class="btn btn-primary"
-                        data-bs-dismiss="modal"
-                        x-text="$store.alertModal.button"
-                    ></button>
-                </div>
+<!-- Alert Modal -->
+<div class="modal fade" id="alertModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="alertModalTitle"></h5>
+                <button
+                    type="button"
+                    class="btn-close"
+                    data-bs-dismiss="modal"
+                    aria-label="Close"
+                ></button>
+            </div>
+            <div class="modal-body">
+                <p id="alertModalBody"></p>
+            </div>
+            <div class="modal-footer">
+                <button
+                    type="button"
+                    class="btn btn-primary"
+                    data-bs-dismiss="modal"
+                    id="alertModalButton"
+                ></button>
             </div>
         </div>
     </div>
@@ -261,41 +251,6 @@
     }
 </script>
 <script>
-    // Initialize Alpine.js stores for modals (CTFd Pattern)
-    // Initialize immediately to avoid undefined store errors
-    if (typeof Alpine !== 'undefined') {
-        Alpine.store('confirmModal', {
-            title: '',
-            body: '',
-            onConfirm: () => {},
-        });
-
-        Alpine.store('alertModal', {
-            title: '',
-            body: '',
-            button: 'Got it!',
-        });
-    }
-
-    // Also listen for alpine:init in case Alpine loads later
-    document.addEventListener('alpine:init', () => {
-        if (!Alpine.store('confirmModal')) {
-            Alpine.store('confirmModal', {
-                title: '',
-                body: '',
-                onConfirm: () => {},
-            });
-        }
-
-        if (!Alpine.store('alertModal')) {
-            Alpine.store('alertModal', {
-                title: '',
-                body: '',
-                button: 'Got it!',
-            });
-        }
-    });
-
     // Vanilla JS modal helpers (framework-agnostic, works with BS4/BS5 CSS)
     function showModal(modalEl) {
         modalEl.classList.add('show');
@@ -331,53 +286,34 @@
             });
     }
 
-    // Check if Alpine.js is available
-    function hasAlpine() {
-        return typeof Alpine !== 'undefined';
-    }
-
-    // Confirmation modal function (CTFd Pattern with Alpine.js)
+    // Confirmation modal function (vanilla JS)
     function ezq(args) {
-        if (!hasAlpine()) {
-            // Fallback to native confirm
-            if (confirm(args.title + '\n\n' + args.body)) {
-                args.success();
-            }
-            return;
-        }
+        var modalEl = document.getElementById('confirmModal');
+        document.getElementById('confirmModalTitle').textContent = args.title;
+        document.getElementById('confirmModalBody').textContent = args.body;
 
-        // Set Alpine store data
-        Alpine.store('confirmModal', {
-            title: args.title,
-            body: args.body,
-            onConfirm: args.success,
+        // Replace Yes button to clear previous listeners
+        var oldBtn = document.getElementById('confirmModalYes');
+        var newBtn = oldBtn.cloneNode(true);
+        oldBtn.parentNode.replaceChild(newBtn, oldBtn);
+        newBtn.addEventListener('click', function () {
+            args.success();
+            hideModal(modalEl);
         });
 
-        // Show modal using vanilla JS
-        const modalElement = document.querySelector('[x-ref="confirmModal"]');
-        bindDismissButtons(modalElement);
-        showModal(modalElement);
+        bindDismissButtons(modalEl);
+        showModal(modalEl);
     }
 
-    // Alert modal function (CTFd Pattern with Alpine.js)
+    // Alert modal function (vanilla JS)
     function ezal(args) {
-        if (!hasAlpine()) {
-            // Fallback to native alert
-            alert(args.title + '\n\n' + args.body);
-            return;
-        }
+        var modalEl = document.getElementById('alertModal');
+        document.getElementById('alertModalTitle').textContent = args.title;
+        document.getElementById('alertModalBody').textContent = args.body;
+        document.getElementById('alertModalButton').textContent = args.button || 'Got it!';
 
-        // Set Alpine store data
-        Alpine.store('alertModal', {
-            title: args.title,
-            body: args.body,
-            button: args.button || 'Got it!',
-        });
-
-        // Show modal using vanilla JS
-        const modalElement = document.querySelector('[x-ref="alertModal"]');
-        bindDismissButtons(modalElement);
-        showModal(modalElement);
+        bindDismissButtons(modalEl);
+        showModal(modalEl);
     }
 </script>
 {% endblock scripts %}

--- a/tests/test_general_docker_api.py
+++ b/tests/test_general_docker_api.py
@@ -518,3 +518,13 @@ def test_delete_service_returns_false_on_none_response(mock_docker_config):
     from docker_challenges.functions.services import delete_service
     result = delete_service(mock_docker_config, "nonexistent_id")
     assert result is False
+
+
+@pytest.mark.medium
+def test_create_container_returns_none_on_unreachable(mock_docker_config):
+    """create_container returns (None, None) when Docker API is unreachable."""
+    mock_docker_config.hostname = ""
+    from docker_challenges.functions.containers import create_container
+    instance_id, data = create_container(mock_docker_config, "nginx:latest", "team1", [], "80/tcp")
+    assert instance_id is None
+    assert data is None


### PR DESCRIPTION
## Summary

- **`delete_docker` returns bool instead of raising `RuntimeError`** — batch operations (stale cleanup, nuke all) now log warnings and continue instead of crashing; single container deletion returns 500 to user
- **Null safety for unreachable Docker API** — `create_container` and `_create_docker_instance` container branch return `None` tuple instead of crashing with `AttributeError`
- **Error differentiation fixed** — `_handle_container_creation` returns `False` for Docker failure vs `None` for rate limiting, making the existing ternary in `ContainerAPI.post` work correctly
- **Frontend modals replaced with vanilla JS** — Alpine.js `x-text`/`@click` directives were never initialized on admin pages (`Alpine.start()` not called by CTFd admin theme), causing empty modal text and dead Yes button on both `admin_docker_status` and `admin_docker_secrets` pages

## Test plan

- [x] 207/207 tests pass
- [x] Pre-commit hooks pass (ruff, bandit, xenon, vulture, prettier)
- [ ] Deploy and verify nuke button works on production
- [ ] Deploy and verify container creation works on production
- [ ] Verify secret deletion confirmation modals work on admin_docker_secrets page