### PR TITLE
fix(frontend): add clipboard fallback for non-secure HTTP contexts

### DIFF
--- a/docker_challenges/assets/view.js
+++ b/docker_challenges/assets/view.js
@@ -308,17 +308,40 @@ function containerStatus(container, challengeId) {
 
         copyConnectionUrl(index, port) {
             var self = this;
-            navigator.clipboard
-                .writeText(port.connectionUrl)
-                .then(function () {
-                    self.copiedIndex = index;
-                    setTimeout(function () {
-                        if (self.copiedIndex === index) self.copiedIndex = -1;
-                    }, 1500);
-                })
-                .catch(function (err) {
-                    console.error('Copy failed:', err);
-                });
+            var text = port.connectionUrl;
+
+            function onSuccess() {
+                self.copiedIndex = index;
+                setTimeout(function () {
+                    if (self.copiedIndex === index) self.copiedIndex = -1;
+                }, 1500);
+            }
+
+            // Clipboard API requires secure context (HTTPS or localhost)
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard
+                    .writeText(text)
+                    .then(onSuccess)
+                    .catch(function (err) {
+                        console.error('Copy failed:', err);
+                    });
+                return;
+            }
+
+            // Fallback for non-secure contexts (HTTP)
+            var textarea = document.createElement('textarea');
+            textarea.value = text;
+            textarea.style.position = 'fixed';
+            textarea.style.opacity = '0';
+            document.body.appendChild(textarea);
+            textarea.select();
+            try {
+                document.execCommand('copy');
+                onSuccess();
+            } catch (err) {
+                console.error('Copy fallback failed:', err);
+            }
+            document.body.removeChild(textarea);
         },
     };
 }


### PR DESCRIPTION
## Summary
- `navigator.clipboard` is `undefined` on HTTP (non-secure contexts), causing `TypeError` when clicking the copy button
- Adds guard check (`navigator.clipboard && navigator.clipboard.writeText`) before calling the Clipboard API
- Falls back to temporary textarea + `document.execCommand('copy')` on HTTP

## Test plan
- [ ] Verify copy button works on HTTPS (Clipboard API path)
- [ ] Verify copy button works on HTTP (execCommand fallback path)
- [ ] Verify "Copied!" checkmark appears and resets after 1.5s on both paths
- [ ] Verify no console errors on either path