### PR TITLE
fix(frontend): check execCommand return value and improve textarea focus

### DIFF
--- a/docker_challenges/assets/view.js
+++ b/docker_challenges/assets/view.js
@@ -334,12 +334,18 @@ function containerStatus(container, challengeId) {
             textarea.style.position = 'fixed';
             textarea.style.opacity = '0';
             document.body.appendChild(textarea);
-            textarea.select();
+            textarea.focus();
+            textarea.setSelectionRange(0, textarea.value.length);
             try {
-                document.execCommand('copy');
-                onSuccess();
+                if (document.execCommand('copy')) {
+                    onSuccess();
+                } else {
+                    console.warn(
+                        'Copy failed: site is not HTTPS. Select the URL and copy manually.'
+                    );
+                }
             } catch (err) {
-                console.error('Copy fallback failed:', err);
+                console.warn('Copy failed: site is not HTTPS. Select the URL and copy manually.');
             }
             document.body.removeChild(textarea);
         },


### PR DESCRIPTION
## Summary
- `document.execCommand('copy')` returns `false` on failure instead of throwing — "Copied!" was shown even when clipboard wasn't updated
- Added return value check so `onSuccess()` only fires on actual success
- Added `textarea.focus()` + `setSelectionRange()` for better cross-browser compatibility
- Logs a user-friendly warning when copy fails due to HTTP context

## Test plan
- [ ] Verify "Copied!" only shows when clipboard is actually updated
- [ ] Verify console warning appears when copy fails on HTTP
- [ ] Verify copy still works on HTTPS (Clipboard API path)