### PR TITLE
chore: bump version 4.0.0 → 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [unreleased]: https://github.com/shiftysheep/CTFd-Docker-Challenges/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/shiftysheep/CTFd-Docker-Challenges/releases/tag/v1.0.0
 
+## v4.0.1 (2026-02-19)
+
+### Feat
+
+- **frontend**: add copyable connection URLs to challenge view (#21)
+
+### Fix
+
+- **models**: auto-populate exposed_ports from image metadata on API create (#26)
+- **frontend**: check execCommand return value and improve textarea focus
+- **frontend**: add clipboard fallback for non-secure HTTP contexts
+- **frontend**: replace Alpine.js modals with vanilla JS DOM manipulation
+- **containers**: add null safety for Docker API unreachable
+- **api**: handle delete_docker failures gracefully in batch operations
+
 ## v4.0.0 (2026-02-17)
 
 ## v3.1.4 (2026-02-17)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plugin for CTFd allows competing teams/users to start dockerized images for
 
 > **For Contributors**: See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code quality standards, and contribution guidelines.
 
-## Version 4.0.0
+## Version 4.0.1
 
 **Latest Update**: Migrated to Alpine.js and Bootstrap 5 for CTFd 3.8.0+ (core theme)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctfd-docker-challenges"
-version = "4.0.0"
+version = "4.0.1"
 description = "Docker-based challenge support for CTFd"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -396,7 +396,7 @@ toml = [
 
 [[package]]
 name = "ctfd-docker-challenges"
-version = "4.0.0"
+version = "4.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
## Summary

- Patch version bump `4.0.0` → `4.0.1`
- Covers fix in PR #26: auto-populate `exposed_ports` from Docker image metadata on API challenge creation