### PR TITLE
fix(frontend): hide copy button when clipboard API unavailable (HTTP)

### DIFF
--- a/docker_challenges/assets/view.html
+++ b/docker_challenges/assets/view.html
@@ -52,6 +52,7 @@
                     </template>
                     <span x-text="port.targetLabel" style="color: #6c7086; font-size: 12px"></span>
                     <button
+                        x-show="canCopy"
                         @click="copyConnectionUrl(index, port)"
                         style="
                             margin-left: auto;

--- a/docker_challenges/assets/view.js
+++ b/docker_challenges/assets/view.js
@@ -104,6 +104,7 @@ function containerStatus(container, challengeId) {
         _destroyed: false,
         _onModalHidden: null,
         copiedIndex: -1,
+        canCopy: !!window.isSecureContext,
 
         async init() {
             await this.pollStatus();
@@ -308,46 +309,12 @@ function containerStatus(container, challengeId) {
 
         copyConnectionUrl(index, port) {
             var self = this;
-            var text = port.connectionUrl;
-
-            function onSuccess() {
+            navigator.clipboard.writeText(port.connectionUrl).then(function () {
                 self.copiedIndex = index;
                 setTimeout(function () {
                     if (self.copiedIndex === index) self.copiedIndex = -1;
                 }, 1500);
-            }
-
-            // Clipboard API requires secure context (HTTPS or localhost)
-            if (navigator.clipboard && navigator.clipboard.writeText) {
-                navigator.clipboard
-                    .writeText(text)
-                    .then(onSuccess)
-                    .catch(function (err) {
-                        console.error('Copy failed:', err);
-                    });
-                return;
-            }
-
-            // Fallback for non-secure contexts (HTTP)
-            var textarea = document.createElement('textarea');
-            textarea.value = text;
-            textarea.style.position = 'fixed';
-            textarea.style.opacity = '0';
-            document.body.appendChild(textarea);
-            textarea.focus();
-            textarea.setSelectionRange(0, textarea.value.length);
-            try {
-                if (document.execCommand('copy')) {
-                    onSuccess();
-                } else {
-                    console.warn(
-                        'Copy failed: site is not HTTPS. Select the URL and copy manually.'
-                    );
-                }
-            } catch (err) {
-                console.warn('Copy failed: site is not HTTPS. Select the URL and copy manually.');
-            }
-            document.body.removeChild(textarea);
+            });
         },
     };
 }


### PR DESCRIPTION
## Summary

- Adds `canCopy: !!window.isSecureContext` to the Alpine.js component data
- Adds `x-show="canCopy"` to the copy button so it only renders on HTTPS/localhost
- Simplifies `copyConnectionUrl` to use only `navigator.clipboard` (removes the `execCommand` fallback since the button is never shown on insecure contexts)

## Test plan

- [ ] On HTTP (`docker compose up`, port 8000): launch a container — copy button should not appear
- [ ] On HTTPS/localhost: copy button appears and copies URL successfully