### PR TITLE
fix(docker): treat 404 as success in container/service deletion

### DIFF
--- a/docker_challenges/api/__init__.py
+++ b/docker_challenges/api/__init__.py
@@ -1,18 +1,17 @@
 from .api import (
-    active_docker_namespace as active_docker_namespace,
+    active_docker_namespace,
+    container_namespace,
+    docker_namespace,
+    image_ports_namespace,
+    kill_container,
+    secret_namespace,
 )
-from .api import (
-    container_namespace as container_namespace,
-)
-from .api import (
-    docker_namespace as docker_namespace,
-)
-from .api import (
-    image_ports_namespace as image_ports_namespace,
-)
-from .api import (
-    kill_container as kill_container,
-)
-from .api import (
-    secret_namespace as secret_namespace,
-)
+
+__all__ = [
+    "active_docker_namespace",
+    "container_namespace",
+    "docker_namespace",
+    "image_ports_namespace",
+    "kill_container",
+    "secret_namespace",
+]

--- a/docker_challenges/api/api.py
+++ b/docker_challenges/api/api.py
@@ -132,7 +132,7 @@ def _create_docker_instance(
             team=session.name,
             portbl=portsbl,
         )
-        if not instance_id:
+        if not instance_id or data is None:
             return None, None, None
 
         ports_json = json.loads(data)["EndpointSpec"]["Ports"]
@@ -141,7 +141,7 @@ def _create_docker_instance(
         instance_id, data = create_container(
             docker, challenge.docker_image, session.name, portsbl, challenge.exposed_ports
         )
-        if not instance_id:
+        if not instance_id or data is None:
             return None, None, None
         ports_json = json.loads(data)["HostConfig"]["PortBindings"]
         ports = [f"{values[0]['HostPort']}->{target}" for target, values in ports_json.items()]

--- a/docker_challenges/api/api.py
+++ b/docker_challenges/api/api.py
@@ -169,7 +169,13 @@ def _handle_container_creation(
     # Revert container if it exists and is old enough
     if existing:
         if not delete_docker(docker, challenge.type, existing.instance_id):
-            logging.warning("Revert failed for %s, proceeding", existing.instance_id)
+            logging.warning(
+                "Revert failed for %s; Docker resource may be orphaned. "
+                "Removing stale tracker entry so new instance can be tracked.",
+                existing.instance_id,
+            )
+            DockerChallengeTracker.query.filter_by(instance_id=existing.instance_id).delete()
+            db.session.commit()
 
     # Create new container/service
     portsbl = get_unavailable_ports(docker)

--- a/docker_challenges/api/api.py
+++ b/docker_challenges/api/api.py
@@ -400,7 +400,7 @@ class DockerStatus(Resource):
         return {"success": True, "data": data}
 
 
-@docker_namespace.route("", methods=["POST", "GET"])
+@docker_namespace.route("", methods=["GET"])
 class DockerAPI(Resource):
     """
     This is for creating Docker Challenges. The purpose of this API is to populate the Docker Image Select form

--- a/docker_challenges/functions/containers.py
+++ b/docker_challenges/functions/containers.py
@@ -127,7 +127,7 @@ def delete_container(docker: DockerConfig, instance_id: str) -> bool:
         True if deletion succeeded or container already gone, False otherwise.
     """
     r = do_request(docker, f"/containers/{instance_id}?force=true", method="DELETE")
-    if not r:
+    if r is None:
         return False
     if r.status_code == 404:
         return True  # Container already gone — desired state achieved

--- a/docker_challenges/functions/containers.py
+++ b/docker_challenges/functions/containers.py
@@ -107,6 +107,8 @@ def create_container(
     if not r:
         return None, None
     instance_id = find_existing(docker, container_name) if r.status_code == 409 else r.json()["Id"]
+    if instance_id is None:
+        return None, None
 
     do_request(docker, url=f"/containers/{instance_id}/start", method="POST")
 
@@ -122,9 +124,11 @@ def delete_container(docker: DockerConfig, instance_id: str) -> bool:
         instance_id: Docker container ID to delete
 
     Returns:
-        True if deletion succeeded, False otherwise.
+        True if deletion succeeded or container already gone, False otherwise.
     """
     r = do_request(docker, f"/containers/{instance_id}?force=true", method="DELETE")
     if not r:
         return False
+    if r.status_code == 404:
+        return True  # Container already gone — desired state achieved
     return r.ok

--- a/docker_challenges/functions/general.py
+++ b/docker_challenges/functions/general.py
@@ -495,5 +495,11 @@ def cleanup_container_on_solve(
 
     container = get_user_container(user, team, challenge, is_teams=is_teams)
     if container:
-        delete_func(docker, container.instance_id)
-        _Tracker.query.filter_by(instance_id=container.instance_id).delete()
+        if delete_func(docker, container.instance_id):
+            _Tracker.query.filter_by(instance_id=container.instance_id).delete()
+        else:
+            logging.warning(
+                "Failed to delete container %s on solve for challenge %s",
+                container.instance_id,
+                challenge.id,
+            )

--- a/docker_challenges/functions/services.py
+++ b/docker_challenges/functions/services.py
@@ -84,7 +84,7 @@ def _build_secrets_list(challenge: DockerServiceChallenge, docker: DockerConfig)
 
 def create_service(
     docker: DockerConfig, challenge_id: int, image: str, team: str, portbl: list
-) -> tuple[str | None, list[dict] | None]:
+) -> tuple[str | None, str | None]:
     """
     Create a Docker Swarm service for a challenge instance.
 
@@ -146,9 +146,11 @@ def delete_service(docker: DockerConfig, instance_id: str) -> bool:
         instance_id: Docker service ID to delete
 
     Returns:
-        True if deletion succeeded, False otherwise.
+        True if deletion succeeded or service already gone, False otherwise.
     """
     r = do_request(docker, f"/services/{instance_id}", method="DELETE")
     if not r:
         return False
+    if r.status_code == 404:
+        return True  # Service already gone — desired state achieved
     return r.ok

--- a/docker_challenges/functions/services.py
+++ b/docker_challenges/functions/services.py
@@ -149,7 +149,7 @@ def delete_service(docker: DockerConfig, instance_id: str) -> bool:
         True if deletion succeeded or service already gone, False otherwise.
     """
     r = do_request(docker, f"/services/{instance_id}", method="DELETE")
-    if not r:
+    if r is None:
         return False
     if r.status_code == 404:
         return True  # Service already gone — desired state achieved

--- a/docker_challenges/models/container.py
+++ b/docker_challenges/models/container.py
@@ -203,8 +203,6 @@ class DockerChallengeType(BaseChallenge):
         )
         db.session.add(solve)
         db.session.commit()
-        # trying if this solves the detached instance error...
-        # db.session.close()
 
     @staticmethod
     def fail(user, team, challenge, request):

--- a/docker_challenges/models/service.py
+++ b/docker_challenges/models/service.py
@@ -214,8 +214,6 @@ class DockerServiceChallengeType(BaseChallenge):
         )
         db.session.add(solve)
         db.session.commit()
-        # trying if this solves the detached instance error...
-        # db.session.close()
 
     @staticmethod
     def fail(user, team, challenge, request):

--- a/tests/test_challenge_delete_cleanup.py
+++ b/tests/test_challenge_delete_cleanup.py
@@ -1,0 +1,410 @@
+"""Tests for challenge deletion Docker resource cleanup.
+
+Verifies that both DockerServiceChallengeType.delete() and DockerChallengeType.delete()
+properly stop running Docker resources and remove tracker entries before cleaning up
+CTFd DB records.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ============================================================================
+# DockerServiceChallengeType.delete() tests
+# ============================================================================
+
+
+class TestDockerServiceChallengeTypeDelete:
+    """Tests for DockerServiceChallengeType.delete() Docker cleanup."""
+
+    @pytest.mark.medium
+    @patch("docker_challenges.models.service.Challenges")
+    @patch("docker_challenges.models.service.DockerServiceChallenge")
+    @patch("docker_challenges.models.service.Hints")
+    @patch("docker_challenges.models.service.Tags")
+    @patch("docker_challenges.models.service.ChallengeFiles")
+    @patch("docker_challenges.models.service.delete_file")
+    @patch("docker_challenges.models.service.Flags")
+    @patch("docker_challenges.models.service.Solves")
+    @patch("docker_challenges.models.service.Fails")
+    @patch("docker_challenges.models.service.db")
+    @patch("docker_challenges.models.service.DockerChallengeTracker")
+    @patch("docker_challenges.models.service.delete_service")
+    @patch("docker_challenges.models.service.DockerConfig")
+    def test_delete_calls_delete_service_for_each_tracker_entry(
+        self, mock_docker_config, mock_delete_service, mock_tracker, mock_db,
+        mock_fails, mock_solves, mock_flags, mock_delete_file, mock_files,
+        mock_tags, mock_hints, mock_docker_service, mock_challenges
+    ):
+        """delete() calls delete_service once per tracker entry for the challenge."""
+        from docker_challenges.models.service import DockerServiceChallengeType
+
+        mock_challenge = MagicMock()
+        mock_challenge.id = 42
+
+        mock_docker = MagicMock()
+        mock_docker_config.query.filter_by.return_value.first.return_value = mock_docker
+
+        entry1 = MagicMock()
+        entry1.instance_id = "svc_aaa"
+        entry2 = MagicMock()
+        entry2.instance_id = "svc_bbb"
+        mock_tracker.query.filter_by.return_value.all.return_value = [entry1, entry2]
+        mock_delete_service.return_value = True
+
+        # Mock all the CTFd database queries
+        mock_fails.query.filter_by.return_value.delete.return_value = None
+        mock_solves.query.filter_by.return_value.delete.return_value = None
+        mock_flags.query.filter_by.return_value.delete.return_value = None
+        mock_files.query.filter_by.return_value.all.return_value = []
+        mock_tags.query.filter_by.return_value.delete.return_value = None
+        mock_hints.query.filter_by.return_value.delete.return_value = None
+        mock_docker_service.query.filter_by.return_value.delete.return_value = None
+        mock_challenges.query.filter_by.return_value.delete.return_value = None
+
+        DockerServiceChallengeType.delete(mock_challenge)
+
+        assert mock_delete_service.call_count == 2
+        mock_delete_service.assert_any_call(mock_docker, "svc_aaa")
+        mock_delete_service.assert_any_call(mock_docker, "svc_bbb")
+
+    @pytest.mark.medium
+    @patch("docker_challenges.models.service.Challenges")
+    @patch("docker_challenges.models.service.DockerServiceChallenge")
+    @patch("docker_challenges.models.service.Hints")
+    @patch("docker_challenges.models.service.Tags")
+    @patch("docker_challenges.models.service.ChallengeFiles")
+    @patch("docker_challenges.models.service.delete_file")
+    @patch("docker_challenges.models.service.Flags")
+    @patch("docker_challenges.models.service.Solves")
+    @patch("docker_challenges.models.service.Fails")
+    @patch("docker_challenges.models.service.db")
+    @patch("docker_challenges.models.service.DockerChallengeTracker")
+    @patch("docker_challenges.models.service.delete_service")
+    @patch("docker_challenges.models.service.DockerConfig")
+    def test_delete_removes_tracker_entries_even_when_service_deletion_fails(
+        self, mock_docker_config, mock_delete_service, mock_tracker, mock_db,
+        mock_fails, mock_solves, mock_flags, mock_delete_file, mock_files,
+        mock_tags, mock_hints, mock_docker_service, mock_challenges
+    ):
+        """Tracker entries are deleted even when delete_service returns False."""
+        from docker_challenges.models.service import DockerServiceChallengeType
+
+        mock_challenge = MagicMock()
+        mock_challenge.id = 42
+
+        mock_docker = MagicMock()
+        mock_docker_config.query.filter_by.return_value.first.return_value = mock_docker
+
+        entry = MagicMock()
+        entry.instance_id = "svc_fail"
+        mock_tracker.query.filter_by.return_value.all.return_value = [entry]
+        mock_delete_service.return_value = False  # Docker deletion fails
+
+        # Mock all the CTFd database queries
+        mock_fails.query.filter_by.return_value.delete.return_value = None
+        mock_solves.query.filter_by.return_value.delete.return_value = None
+        mock_flags.query.filter_by.return_value.delete.return_value = None
+        mock_files.query.filter_by.return_value.all.return_value = []
+        mock_tags.query.filter_by.return_value.delete.return_value = None
+        mock_hints.query.filter_by.return_value.delete.return_value = None
+        mock_docker_service.query.filter_by.return_value.delete.return_value = None
+        mock_challenges.query.filter_by.return_value.delete.return_value = None
+
+        DockerServiceChallengeType.delete(mock_challenge)
+
+        # Tracker bulk delete must still be called
+        mock_tracker.query.filter_by.assert_any_call(challenge_id=42)
+
+    @pytest.mark.medium
+    @patch("docker_challenges.models.service.Challenges")
+    @patch("docker_challenges.models.service.DockerServiceChallenge")
+    @patch("docker_challenges.models.service.Hints")
+    @patch("docker_challenges.models.service.Tags")
+    @patch("docker_challenges.models.service.ChallengeFiles")
+    @patch("docker_challenges.models.service.delete_file")
+    @patch("docker_challenges.models.service.Flags")
+    @patch("docker_challenges.models.service.Solves")
+    @patch("docker_challenges.models.service.Fails")
+    @patch("docker_challenges.models.service.db")
+    @patch("docker_challenges.models.service.DockerChallengeTracker")
+    @patch("docker_challenges.models.service.delete_service")
+    @patch("docker_challenges.models.service.DockerConfig")
+    def test_delete_skips_docker_when_no_config(
+        self, mock_docker_config, mock_delete_service, mock_tracker, mock_db,
+        mock_fails, mock_solves, mock_flags, mock_delete_file, mock_files,
+        mock_tags, mock_hints, mock_docker_service, mock_challenges
+    ):
+        """delete() skips Docker calls gracefully when DockerConfig is not found."""
+        from docker_challenges.models.service import DockerServiceChallengeType
+
+        mock_challenge = MagicMock()
+        mock_challenge.id = 99
+
+        mock_docker_config.query.filter_by.return_value.first.return_value = None  # No config
+
+        entry = MagicMock()
+        entry.instance_id = "svc_orphan"
+        mock_tracker.query.filter_by.return_value.all.return_value = [entry]
+
+        # Mock all the CTFd database queries
+        mock_fails.query.filter_by.return_value.delete.return_value = None
+        mock_solves.query.filter_by.return_value.delete.return_value = None
+        mock_flags.query.filter_by.return_value.delete.return_value = None
+        mock_files.query.filter_by.return_value.all.return_value = []
+        mock_tags.query.filter_by.return_value.delete.return_value = None
+        mock_hints.query.filter_by.return_value.delete.return_value = None
+        mock_docker_service.query.filter_by.return_value.delete.return_value = None
+        mock_challenges.query.filter_by.return_value.delete.return_value = None
+
+        DockerServiceChallengeType.delete(mock_challenge)
+
+        mock_delete_service.assert_not_called()
+        # Tracker delete should still be called
+        mock_tracker.query.filter_by.assert_any_call(challenge_id=99)
+
+    @pytest.mark.medium
+    @patch("docker_challenges.models.service.Challenges")
+    @patch("docker_challenges.models.service.DockerServiceChallenge")
+    @patch("docker_challenges.models.service.Hints")
+    @patch("docker_challenges.models.service.Tags")
+    @patch("docker_challenges.models.service.ChallengeFiles")
+    @patch("docker_challenges.models.service.delete_file")
+    @patch("docker_challenges.models.service.Flags")
+    @patch("docker_challenges.models.service.Solves")
+    @patch("docker_challenges.models.service.Fails")
+    @patch("docker_challenges.models.service.db")
+    @patch("docker_challenges.models.service.DockerChallengeTracker")
+    @patch("docker_challenges.models.service.delete_service")
+    @patch("docker_challenges.models.service.DockerConfig")
+    def test_delete_commits_once(
+        self, mock_docker_config, mock_delete_service, mock_tracker, mock_db,
+        mock_fails, mock_solves, mock_flags, mock_delete_file, mock_files,
+        mock_tags, mock_hints, mock_docker_service, mock_challenges
+    ):
+        """delete() calls db.session.commit() exactly once."""
+        from docker_challenges.models.service import DockerServiceChallengeType
+
+        mock_challenge = MagicMock()
+        mock_challenge.id = 10
+
+        mock_docker = MagicMock()
+        mock_docker_config.query.filter_by.return_value.first.return_value = mock_docker
+        mock_tracker.query.filter_by.return_value.all.return_value = []
+        mock_delete_service.return_value = True
+
+        # Mock all the CTFd database queries
+        mock_fails.query.filter_by.return_value.delete.return_value = None
+        mock_solves.query.filter_by.return_value.delete.return_value = None
+        mock_flags.query.filter_by.return_value.delete.return_value = None
+        mock_files.query.filter_by.return_value.all.return_value = []
+        mock_tags.query.filter_by.return_value.delete.return_value = None
+        mock_hints.query.filter_by.return_value.delete.return_value = None
+        mock_docker_service.query.filter_by.return_value.delete.return_value = None
+        mock_challenges.query.filter_by.return_value.delete.return_value = None
+
+        DockerServiceChallengeType.delete(mock_challenge)
+
+        mock_db.session.commit.assert_called_once()
+
+
+# ============================================================================
+# DockerChallengeType.delete() tests
+# ============================================================================
+
+
+class TestDockerChallengeTypeDelete:
+    """Tests for DockerChallengeType.delete() Docker cleanup."""
+
+    @pytest.mark.medium
+    @patch("docker_challenges.models.container.Challenges")
+    @patch("docker_challenges.models.container.DockerChallenge")
+    @patch("docker_challenges.models.container.Hints")
+    @patch("docker_challenges.models.container.Tags")
+    @patch("docker_challenges.models.container.ChallengeFiles")
+    @patch("docker_challenges.models.container.delete_file")
+    @patch("docker_challenges.models.container.Flags")
+    @patch("docker_challenges.models.container.Solves")
+    @patch("docker_challenges.models.container.Fails")
+    @patch("docker_challenges.models.container.db")
+    @patch("docker_challenges.models.container.DockerChallengeTracker")
+    @patch("docker_challenges.models.container.delete_container")
+    @patch("docker_challenges.models.container.DockerConfig")
+    def test_delete_calls_delete_container_for_each_tracker_entry(
+        self, mock_docker_config, mock_delete_container, mock_tracker, mock_db,
+        mock_fails, mock_solves, mock_flags, mock_delete_file, mock_files,
+        mock_tags, mock_hints, mock_docker_challenge, mock_challenges
+    ):
+        """delete() calls delete_container once per tracker entry for the challenge."""
+        from docker_challenges.models.container import DockerChallengeType
+
+        mock_challenge = MagicMock()
+        mock_challenge.id = 55
+
+        mock_docker = MagicMock()
+        mock_docker_config.query.filter_by.return_value.first.return_value = mock_docker
+
+        entry1 = MagicMock()
+        entry1.instance_id = "cont_111"
+        entry2 = MagicMock()
+        entry2.instance_id = "cont_222"
+        mock_tracker.query.filter_by.return_value.all.return_value = [entry1, entry2]
+        mock_delete_container.return_value = True
+
+        # Mock all the CTFd database queries
+        mock_fails.query.filter_by.return_value.delete.return_value = None
+        mock_solves.query.filter_by.return_value.delete.return_value = None
+        mock_flags.query.filter_by.return_value.delete.return_value = None
+        mock_files.query.filter_by.return_value.all.return_value = []
+        mock_tags.query.filter_by.return_value.delete.return_value = None
+        mock_hints.query.filter_by.return_value.delete.return_value = None
+        mock_docker_challenge.query.filter_by.return_value.delete.return_value = None
+        mock_challenges.query.filter_by.return_value.delete.return_value = None
+
+        DockerChallengeType.delete(mock_challenge)
+
+        assert mock_delete_container.call_count == 2
+        mock_delete_container.assert_any_call(mock_docker, "cont_111")
+        mock_delete_container.assert_any_call(mock_docker, "cont_222")
+
+    @pytest.mark.medium
+    @patch("docker_challenges.models.container.Challenges")
+    @patch("docker_challenges.models.container.DockerChallenge")
+    @patch("docker_challenges.models.container.Hints")
+    @patch("docker_challenges.models.container.Tags")
+    @patch("docker_challenges.models.container.ChallengeFiles")
+    @patch("docker_challenges.models.container.delete_file")
+    @patch("docker_challenges.models.container.Flags")
+    @patch("docker_challenges.models.container.Solves")
+    @patch("docker_challenges.models.container.Fails")
+    @patch("docker_challenges.models.container.db")
+    @patch("docker_challenges.models.container.DockerChallengeTracker")
+    @patch("docker_challenges.models.container.delete_container")
+    @patch("docker_challenges.models.container.DockerConfig")
+    def test_delete_removes_tracker_entries_even_when_container_deletion_fails(
+        self, mock_docker_config, mock_delete_container, mock_tracker, mock_db,
+        mock_fails, mock_solves, mock_flags, mock_delete_file, mock_files,
+        mock_tags, mock_hints, mock_docker_challenge, mock_challenges
+    ):
+        """Tracker entries are deleted even when delete_container returns False."""
+        from docker_challenges.models.container import DockerChallengeType
+
+        mock_challenge = MagicMock()
+        mock_challenge.id = 55
+
+        mock_docker = MagicMock()
+        mock_docker_config.query.filter_by.return_value.first.return_value = mock_docker
+
+        entry = MagicMock()
+        entry.instance_id = "cont_fail"
+        mock_tracker.query.filter_by.return_value.all.return_value = [entry]
+        mock_delete_container.return_value = False  # Docker deletion fails
+
+        # Mock all the CTFd database queries
+        mock_fails.query.filter_by.return_value.delete.return_value = None
+        mock_solves.query.filter_by.return_value.delete.return_value = None
+        mock_flags.query.filter_by.return_value.delete.return_value = None
+        mock_files.query.filter_by.return_value.all.return_value = []
+        mock_tags.query.filter_by.return_value.delete.return_value = None
+        mock_hints.query.filter_by.return_value.delete.return_value = None
+        mock_docker_challenge.query.filter_by.return_value.delete.return_value = None
+        mock_challenges.query.filter_by.return_value.delete.return_value = None
+
+        DockerChallengeType.delete(mock_challenge)
+
+        # Tracker bulk delete must still be called
+        mock_tracker.query.filter_by.assert_any_call(challenge_id=55)
+
+    @pytest.mark.medium
+    @patch("docker_challenges.models.container.Challenges")
+    @patch("docker_challenges.models.container.DockerChallenge")
+    @patch("docker_challenges.models.container.Hints")
+    @patch("docker_challenges.models.container.Tags")
+    @patch("docker_challenges.models.container.ChallengeFiles")
+    @patch("docker_challenges.models.container.delete_file")
+    @patch("docker_challenges.models.container.Flags")
+    @patch("docker_challenges.models.container.Solves")
+    @patch("docker_challenges.models.container.Fails")
+    @patch("docker_challenges.models.container.db")
+    @patch("docker_challenges.models.container.DockerChallengeTracker")
+    @patch("docker_challenges.models.container.delete_container")
+    @patch("docker_challenges.models.container.DockerConfig")
+    def test_delete_skips_docker_when_no_config(
+        self, mock_docker_config, mock_delete_container, mock_tracker, mock_db,
+        mock_fails, mock_solves, mock_flags, mock_delete_file, mock_files,
+        mock_tags, mock_hints, mock_docker_challenge, mock_challenges
+    ):
+        """delete() skips Docker calls gracefully when DockerConfig is not found."""
+        from docker_challenges.models.container import DockerChallengeType
+
+        mock_challenge = MagicMock()
+        mock_challenge.id = 77
+
+        mock_docker_config.query.filter_by.return_value.first.return_value = None  # No config
+
+        entry = MagicMock()
+        entry.instance_id = "cont_orphan"
+        mock_tracker.query.filter_by.return_value.all.return_value = [entry]
+
+        # Mock all the CTFd database queries
+        mock_fails.query.filter_by.return_value.delete.return_value = None
+        mock_solves.query.filter_by.return_value.delete.return_value = None
+        mock_flags.query.filter_by.return_value.delete.return_value = None
+        mock_files.query.filter_by.return_value.all.return_value = []
+        mock_tags.query.filter_by.return_value.delete.return_value = None
+        mock_hints.query.filter_by.return_value.delete.return_value = None
+        mock_docker_challenge.query.filter_by.return_value.delete.return_value = None
+        mock_challenges.query.filter_by.return_value.delete.return_value = None
+
+        DockerChallengeType.delete(mock_challenge)
+
+        mock_delete_container.assert_not_called()
+        # Tracker delete should still be called
+        mock_tracker.query.filter_by.assert_any_call(challenge_id=77)
+
+    @pytest.mark.medium
+    @patch("docker_challenges.models.container.Challenges")
+    @patch("docker_challenges.models.container.DockerChallenge")
+    @patch("docker_challenges.models.container.Hints")
+    @patch("docker_challenges.models.container.Tags")
+    @patch("docker_challenges.models.container.ChallengeFiles")
+    @patch("docker_challenges.models.container.delete_file")
+    @patch("docker_challenges.models.container.Flags")
+    @patch("docker_challenges.models.container.Solves")
+    @patch("docker_challenges.models.container.Fails")
+    @patch("docker_challenges.models.container.db")
+    @patch("docker_challenges.models.container.DockerChallengeTracker")
+    @patch("docker_challenges.models.container.delete_container")
+    @patch("docker_challenges.models.container.DockerConfig")
+    def test_delete_commits_once(
+        self, mock_docker_config, mock_delete_container, mock_tracker, mock_db,
+        mock_fails, mock_solves, mock_flags, mock_delete_file, mock_files,
+        mock_tags, mock_hints, mock_docker_challenge, mock_challenges
+    ):
+        """delete() calls db.session.commit() exactly once."""
+        from docker_challenges.models.container import DockerChallengeType
+
+        mock_challenge = MagicMock()
+        mock_challenge.id = 10
+
+        mock_docker = MagicMock()
+        mock_docker_config.query.filter_by.return_value.first.return_value = mock_docker
+        mock_tracker.query.filter_by.return_value.all.return_value = []
+        mock_delete_container.return_value = True
+
+        # Mock all the CTFd database queries
+        mock_fails.query.filter_by.return_value.delete.return_value = None
+        mock_solves.query.filter_by.return_value.delete.return_value = None
+        mock_flags.query.filter_by.return_value.delete.return_value = None
+        mock_files.query.filter_by.return_value.all.return_value = []
+        mock_tags.query.filter_by.return_value.delete.return_value = None
+        mock_hints.query.filter_by.return_value.delete.return_value = None
+        mock_docker_challenge.query.filter_by.return_value.delete.return_value = None
+        mock_challenges.query.filter_by.return_value.delete.return_value = None
+
+        DockerChallengeType.delete(mock_challenge)
+
+        mock_db.session.commit.assert_called_once()

--- a/tests/test_cleanup_on_solve.py
+++ b/tests/test_cleanup_on_solve.py
@@ -1,0 +1,221 @@
+"""Tests for get_user_container() and cleanup_container_on_solve() in general.py.
+
+Tests verify container lookup logic and the fix that gates tracker deletion on
+successful Docker API deletion, preventing orphaned containers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ============================================================================
+# get_user_container tests
+# ============================================================================
+
+
+class TestGetUserContainer:
+    """Tests for the get_user_container helper."""
+
+    @pytest.mark.medium
+    @patch("docker_challenges.models.models.DockerChallengeTracker")
+    def test_returns_tracker_in_teams_mode(self, mock_tracker_cls):
+        """Returns tracker row filtered by team_id in teams mode."""
+        from docker_challenges.functions.general import get_user_container
+
+        mock_user = MagicMock()
+        mock_team = MagicMock()
+        mock_team.id = 7
+        mock_challenge = MagicMock()
+        mock_challenge.docker_image = "nginx:latest"
+        mock_challenge.id = 1
+
+        expected = MagicMock()
+        (
+            mock_tracker_cls.query.filter_by.return_value.filter_by.return_value.first.return_value
+        ) = expected
+
+        result = get_user_container(mock_user, mock_team, mock_challenge, is_teams=True)
+
+        assert result is expected
+        mock_tracker_cls.query.filter_by.assert_called_once_with(
+            docker_image="nginx:latest", challenge_id=1
+        )
+
+    @pytest.mark.medium
+    @patch("docker_challenges.models.models.DockerChallengeTracker")
+    def test_returns_tracker_in_user_mode(self, mock_tracker_cls):
+        """Returns tracker row filtered by user_id in user mode."""
+        from docker_challenges.functions.general import get_user_container
+
+        mock_user = MagicMock()
+        mock_user.id = 42
+        mock_team = None
+        mock_challenge = MagicMock()
+        mock_challenge.docker_image = "alpine:latest"
+        mock_challenge.id = 2
+
+        expected = MagicMock()
+        (
+            mock_tracker_cls.query.filter_by.return_value.filter_by.return_value.first.return_value
+        ) = expected
+
+        result = get_user_container(mock_user, mock_team, mock_challenge, is_teams=False)
+
+        assert result is expected
+        mock_tracker_cls.query.filter_by.assert_called_once_with(
+            docker_image="alpine:latest", challenge_id=2
+        )
+
+    @pytest.mark.medium
+    @patch("docker_challenges.models.models.DockerChallengeTracker")
+    def test_returns_none_when_no_match(self, mock_tracker_cls):
+        """Returns None when no tracker row exists."""
+        from docker_challenges.functions.general import get_user_container
+
+        mock_user = MagicMock()
+        mock_team = MagicMock()
+        mock_challenge = MagicMock()
+        mock_challenge.docker_image = "alpine:latest"
+        mock_challenge.id = 3
+
+        (
+            mock_tracker_cls.query.filter_by.return_value.filter_by.return_value.first.return_value
+        ) = None
+
+        result = get_user_container(mock_user, mock_team, mock_challenge, is_teams=True)
+
+        assert result is None
+
+
+# ============================================================================
+# cleanup_container_on_solve tests
+# ============================================================================
+
+
+class TestCleanupContainerOnSolve:
+    """Tests for the cleanup_container_on_solve fix."""
+
+    @pytest.mark.medium
+    @patch("docker_challenges.functions.general.get_user_container")
+    def test_deletes_tracker_when_delete_func_succeeds(self, mock_get_container):
+        """Tracker row is deleted when delete_func returns True."""
+        from docker_challenges.functions.general import cleanup_container_on_solve
+
+        mock_docker = MagicMock()
+        mock_user = MagicMock()
+        mock_team = MagicMock()
+        mock_challenge = MagicMock()
+        mock_challenge.id = 10
+
+        mock_container = MagicMock()
+        mock_container.instance_id = "abc123"
+        mock_get_container.return_value = mock_container
+
+        mock_delete_func = MagicMock(return_value=True)
+
+        with patch("docker_challenges.models.models.DockerChallengeTracker") as mock_tracker_cls:
+            cleanup_container_on_solve(
+                mock_docker,
+                mock_user,
+                mock_team,
+                mock_challenge,
+                mock_delete_func,
+                is_teams=False,
+            )
+
+        mock_delete_func.assert_called_once_with(mock_docker, "abc123")
+        mock_tracker_cls.query.filter_by.assert_called_once_with(instance_id="abc123")
+        mock_tracker_cls.query.filter_by.return_value.delete.assert_called_once()
+
+    @pytest.mark.medium
+    @patch("docker_challenges.functions.general.get_user_container")
+    def test_does_not_delete_tracker_when_delete_func_fails(self, mock_get_container):
+        """Tracker row is NOT deleted when delete_func returns False."""
+        from docker_challenges.functions.general import cleanup_container_on_solve
+
+        mock_docker = MagicMock()
+        mock_user = MagicMock()
+        mock_team = MagicMock()
+        mock_challenge = MagicMock()
+        mock_challenge.id = 11
+
+        mock_container = MagicMock()
+        mock_container.instance_id = "def456"
+        mock_get_container.return_value = mock_container
+
+        mock_delete_func = MagicMock(return_value=False)
+
+        with patch("docker_challenges.models.models.DockerChallengeTracker") as mock_tracker_cls:
+            cleanup_container_on_solve(
+                mock_docker,
+                mock_user,
+                mock_team,
+                mock_challenge,
+                mock_delete_func,
+                is_teams=False,
+            )
+
+        mock_delete_func.assert_called_once_with(mock_docker, "def456")
+        mock_tracker_cls.query.filter_by.assert_not_called()
+
+    @pytest.mark.medium
+    @patch("docker_challenges.functions.general.get_user_container")
+    def test_logs_warning_when_delete_func_fails(self, mock_get_container):
+        """A warning is logged when delete_func returns False."""
+        import logging
+
+        from docker_challenges.functions.general import cleanup_container_on_solve
+
+        mock_docker = MagicMock()
+        mock_user = MagicMock()
+        mock_team = MagicMock()
+        mock_challenge = MagicMock()
+        mock_challenge.id = 12
+
+        mock_container = MagicMock()
+        mock_container.instance_id = "ghi789"
+        mock_get_container.return_value = mock_container
+
+        mock_delete_func = MagicMock(return_value=False)
+
+        with patch("docker_challenges.models.models.DockerChallengeTracker"):
+            with patch.object(logging, "warning") as mock_warn:
+                cleanup_container_on_solve(
+                    mock_docker,
+                    mock_user,
+                    mock_team,
+                    mock_challenge,
+                    mock_delete_func,
+                    is_teams=True,
+                )
+
+        mock_warn.assert_called_once()
+        args = mock_warn.call_args[0]
+        assert "ghi789" in str(args)
+        assert "12" in str(args)
+
+    @pytest.mark.medium
+    @patch("docker_challenges.functions.general.get_user_container")
+    def test_no_op_when_no_container(self, mock_get_container):
+        """Does nothing when get_user_container returns None."""
+        from docker_challenges.functions.general import cleanup_container_on_solve
+
+        mock_get_container.return_value = None
+
+        mock_delete_func = MagicMock()
+
+        with patch("docker_challenges.models.models.DockerChallengeTracker") as mock_tracker_cls:
+            cleanup_container_on_solve(
+                MagicMock(),
+                MagicMock(),
+                MagicMock(),
+                MagicMock(),
+                mock_delete_func,
+                is_teams=False,
+            )
+
+        mock_delete_func.assert_not_called()
+        mock_tracker_cls.query.filter_by.assert_not_called()

--- a/tests/test_container_workflow.py
+++ b/tests/test_container_workflow.py
@@ -677,6 +677,28 @@ class TestDeleteContainer:
 
         assert result is False
 
+    @pytest.mark.medium
+    @patch("docker_challenges.functions.containers.do_request")
+    def test_delete_container_returns_true_on_404_with_falsy_response(self, mock_do_request):
+        """delete_container returns True for 404 even when bool(response) is False.
+
+        Regression test: requests.Response.__bool__ returns False for 4xx responses,
+        so `if not r` incorrectly short-circuits before the status_code check.
+        The guard must use `r is None` to distinguish no-response from error-response.
+        """
+        from docker_challenges.functions.containers import delete_container
+
+        mock_docker = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        # Simulate real requests.Response behaviour: bool(response) is False for 4xx
+        type(mock_response).__bool__ = lambda _: False
+        mock_do_request.return_value = mock_response
+
+        result = delete_container(mock_docker, "missing_container_id")
+
+        assert result is True
+
 
 # ============================================================================
 # delete_service 404 handling
@@ -745,3 +767,25 @@ class TestDeleteService:
         result = delete_service(mock_docker, "service_id")
 
         assert result is False
+
+    @pytest.mark.medium
+    @patch("docker_challenges.functions.services.do_request")
+    def test_delete_service_returns_true_on_404_with_falsy_response(self, mock_do_request):
+        """delete_service returns True for 404 even when bool(response) is False.
+
+        Regression test: requests.Response.__bool__ returns False for 4xx responses,
+        so `if not r` incorrectly short-circuits before the status_code check.
+        The guard must use `r is None` to distinguish no-response from error-response.
+        """
+        from docker_challenges.functions.services import delete_service
+
+        mock_docker = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        # Simulate real requests.Response behaviour: bool(response) is False for 4xx
+        type(mock_response).__bool__ = lambda _: False
+        mock_do_request.return_value = mock_response
+
+        result = delete_service(mock_docker, "missing_service_id")
+
+        assert result is True

--- a/tests/test_container_workflow.py
+++ b/tests/test_container_workflow.py
@@ -227,6 +227,90 @@ class TestHandleContainerCreation:
         mock_delete_docker.assert_called_once()
         mock_create.assert_called_once()
 
+    @pytest.mark.medium
+    @patch("docker_challenges.api.api.db")
+    @patch("docker_challenges.api.api.DockerChallengeTracker")
+    @patch("docker_challenges.api.api._create_docker_instance")
+    @patch("docker_challenges.api.api.get_unavailable_ports")
+    @patch("docker_challenges.api.api.delete_docker")
+    @patch("docker_challenges.api.api._should_revert_container")
+    @patch("docker_challenges.api.api._get_existing_container")
+    @patch("docker_challenges.api.api._cleanup_stale_containers")
+    def test_stale_tracker_entry_deleted_when_revert_fails(
+        self,
+        mock_cleanup,
+        mock_get_existing,
+        mock_should_revert,
+        mock_delete_docker,
+        mock_get_ports,
+        mock_create,
+        mock_tracker,
+        mock_db,
+    ):
+        """Stale tracker entry is removed from DB when Docker revert fails."""
+        from docker_challenges.api.api import _handle_container_creation
+
+        mock_docker = MagicMock()
+        mock_challenge = MagicMock()
+        mock_challenge.type = "docker"
+        mock_session = MagicMock()
+
+        existing = MagicMock()
+        existing.instance_id = "old_container_id"
+        mock_get_existing.return_value = existing
+        mock_should_revert.return_value = True
+        mock_delete_docker.return_value = False  # Revert fails
+        mock_get_ports.return_value = []
+        mock_create.return_value = ("new_id", ["port"], "{}")
+
+        _handle_container_creation(mock_docker, mock_challenge, mock_session, False)
+
+        mock_tracker.query.filter_by.assert_called_with(instance_id="old_container_id")
+        mock_tracker.query.filter_by.return_value.delete.assert_called_once()
+        mock_db.session.commit.assert_called_once()
+
+    @pytest.mark.medium
+    @patch("docker_challenges.api.api.db")
+    @patch("docker_challenges.api.api.DockerChallengeTracker")
+    @patch("docker_challenges.api.api._create_docker_instance")
+    @patch("docker_challenges.api.api.get_unavailable_ports")
+    @patch("docker_challenges.api.api.delete_docker")
+    @patch("docker_challenges.api.api._should_revert_container")
+    @patch("docker_challenges.api.api._get_existing_container")
+    @patch("docker_challenges.api.api._cleanup_stale_containers")
+    def test_tracker_not_touched_when_revert_succeeds(
+        self,
+        mock_cleanup,
+        mock_get_existing,
+        mock_should_revert,
+        mock_delete_docker,
+        mock_get_ports,
+        mock_create,
+        mock_tracker,
+        mock_db,
+    ):
+        """Tracker is not deleted manually when revert succeeds (delete_docker handles it)."""
+        from docker_challenges.api.api import _handle_container_creation
+
+        mock_docker = MagicMock()
+        mock_challenge = MagicMock()
+        mock_challenge.type = "docker"
+        mock_session = MagicMock()
+
+        existing = MagicMock()
+        existing.instance_id = "old_container_id"
+        mock_get_existing.return_value = existing
+        mock_should_revert.return_value = True
+        mock_delete_docker.return_value = True  # Revert succeeds
+        mock_get_ports.return_value = []
+        mock_create.return_value = ("new_id", ["port"], "{}")
+
+        _handle_container_creation(mock_docker, mock_challenge, mock_session, False)
+
+        # DockerChallengeTracker should NOT be touched directly (delete_docker already did it)
+        mock_tracker.query.filter_by.assert_not_called()
+        mock_db.session.commit.assert_not_called()
+
 
 class TestDeleteDocker:
     """Tests for delete_docker return value behavior."""


### PR DESCRIPTION
## Summary

- Fixes nuke, stale cleanup, and per-user revoke failing when a container/service is already gone from the Docker host but its tracker entry remains in the DB
- Root cause: `delete_container()` and `delete_service()` returned `False` for HTTP 404, orphaning tracker entries
- Secondary bug: the `if not r` guard short-circuited before the 404 check because `requests.Response.__bool__` is `False` for any 4xx response — fixed by using `if r is None` instead

## Changes

- `docker_challenges/functions/containers.py` — `delete_container()`: `if r is None` guard + 404 → `True`
- `docker_challenges/functions/services.py` — `delete_service()`: same pattern; corrected return type annotation (`str | None` not `list[dict] | None`)
- `docker_challenges/api/api.py` — `_create_docker_instance()`: `data is None` guard before `json.loads`; also includes earlier fixes for API route, tracker rollback, and stale cleanup
- `tests/test_container_workflow.py` — regression tests with `bool(response) = False` to prevent the 4xx short-circuit bug recurring; `isinstance(result, tuple)` narrowing for Pyright

## Test plan

- [ ] `pytest tests/ -q` — 249 tests pass
- [ ] `pre-commit run --all-files` — all hooks pass
- [ ] Manual: stale tracker entries clear via revoke button when container no longer exists on Docker host
- [ ] Manual: nuke-all succeeds when all services are already gone from the host