### PR TITLE
fix(docker): treat 404 as success in container/service deletion

### DIFF
--- a/docker_challenges/api/api.py
+++ b/docker_challenges/api/api.py
@@ -132,7 +132,7 @@ def _create_docker_instance(
             team=session.name,
             portbl=portsbl,
         )
-        if not instance_id:
+        if not instance_id or data is None:
             return None, None, None
 
         ports_json = json.loads(data)["EndpointSpec"]["Ports"]
@@ -141,7 +141,7 @@ def _create_docker_instance(
         instance_id, data = create_container(
             docker, challenge.docker_image, session.name, portsbl, challenge.exposed_ports
         )
-        if not instance_id:
+        if not instance_id or data is None:
             return None, None, None
         ports_json = json.loads(data)["HostConfig"]["PortBindings"]
         ports = [f"{values[0]['HostPort']}->{target}" for target, values in ports_json.items()]

--- a/docker_challenges/functions/containers.py
+++ b/docker_challenges/functions/containers.py
@@ -127,7 +127,7 @@ def delete_container(docker: DockerConfig, instance_id: str) -> bool:
         True if deletion succeeded or container already gone, False otherwise.
     """
     r = do_request(docker, f"/containers/{instance_id}?force=true", method="DELETE")
-    if not r:
+    if r is None:
         return False
     if r.status_code == 404:
         return True  # Container already gone — desired state achieved

--- a/docker_challenges/functions/containers.py
+++ b/docker_challenges/functions/containers.py
@@ -107,6 +107,8 @@ def create_container(
     if not r:
         return None, None
     instance_id = find_existing(docker, container_name) if r.status_code == 409 else r.json()["Id"]
+    if instance_id is None:
+        return None, None
 
     do_request(docker, url=f"/containers/{instance_id}/start", method="POST")
 
@@ -122,9 +124,11 @@ def delete_container(docker: DockerConfig, instance_id: str) -> bool:
         instance_id: Docker container ID to delete
 
     Returns:
-        True if deletion succeeded, False otherwise.
+        True if deletion succeeded or container already gone, False otherwise.
     """
     r = do_request(docker, f"/containers/{instance_id}?force=true", method="DELETE")
     if not r:
         return False
+    if r.status_code == 404:
+        return True  # Container already gone — desired state achieved
     return r.ok

--- a/docker_challenges/functions/services.py
+++ b/docker_challenges/functions/services.py
@@ -84,7 +84,7 @@ def _build_secrets_list(challenge: DockerServiceChallenge, docker: DockerConfig)
 
 def create_service(
     docker: DockerConfig, challenge_id: int, image: str, team: str, portbl: list
-) -> tuple[str | None, list[dict] | None]:
+) -> tuple[str | None, str | None]:
     """
     Create a Docker Swarm service for a challenge instance.
 
@@ -146,9 +146,11 @@ def delete_service(docker: DockerConfig, instance_id: str) -> bool:
         instance_id: Docker service ID to delete
 
     Returns:
-        True if deletion succeeded, False otherwise.
+        True if deletion succeeded or service already gone, False otherwise.
     """
     r = do_request(docker, f"/services/{instance_id}", method="DELETE")
     if not r:
         return False
+    if r.status_code == 404:
+        return True  # Service already gone — desired state achieved
     return r.ok

--- a/docker_challenges/functions/services.py
+++ b/docker_challenges/functions/services.py
@@ -149,7 +149,7 @@ def delete_service(docker: DockerConfig, instance_id: str) -> bool:
         True if deletion succeeded or service already gone, False otherwise.
     """
     r = do_request(docker, f"/services/{instance_id}", method="DELETE")
-    if not r:
+    if r is None:
         return False
     if r.status_code == 404:
         return True  # Service already gone — desired state achieved

--- a/tests/test_container_workflow.py
+++ b/tests/test_container_workflow.py
@@ -677,6 +677,28 @@ class TestDeleteContainer:
 
         assert result is False
 
+    @pytest.mark.medium
+    @patch("docker_challenges.functions.containers.do_request")
+    def test_delete_container_returns_true_on_404_with_falsy_response(self, mock_do_request):
+        """delete_container returns True for 404 even when bool(response) is False.
+
+        Regression test: requests.Response.__bool__ returns False for 4xx responses,
+        so `if not r` incorrectly short-circuits before the status_code check.
+        The guard must use `r is None` to distinguish no-response from error-response.
+        """
+        from docker_challenges.functions.containers import delete_container
+
+        mock_docker = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        # Simulate real requests.Response behaviour: bool(response) is False for 4xx
+        type(mock_response).__bool__ = lambda _: False
+        mock_do_request.return_value = mock_response
+
+        result = delete_container(mock_docker, "missing_container_id")
+
+        assert result is True
+
 
 # ============================================================================
 # delete_service 404 handling
@@ -745,3 +767,25 @@ class TestDeleteService:
         result = delete_service(mock_docker, "service_id")
 
         assert result is False
+
+    @pytest.mark.medium
+    @patch("docker_challenges.functions.services.do_request")
+    def test_delete_service_returns_true_on_404_with_falsy_response(self, mock_do_request):
+        """delete_service returns True for 404 even when bool(response) is False.
+
+        Regression test: requests.Response.__bool__ returns False for 4xx responses,
+        so `if not r` incorrectly short-circuits before the status_code check.
+        The guard must use `r is None` to distinguish no-response from error-response.
+        """
+        from docker_challenges.functions.services import delete_service
+
+        mock_docker = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        # Simulate real requests.Response behaviour: bool(response) is False for 4xx
+        type(mock_response).__bool__ = lambda _: False
+        mock_do_request.return_value = mock_response
+
+        result = delete_service(mock_docker, "missing_service_id")
+
+        assert result is True


### PR DESCRIPTION
## Summary

- Fixes nuke, stale cleanup, and per-user revoke failing when a container/service is already gone from the Docker host but its tracker entry remains in the DB
- Root cause 1: `delete_container()` and `delete_service()` returned `False` for HTTP 404, orphaning tracker entries
- Root cause 2: `if not r` guard short-circuited before the 404 check because `requests.Response.__bool__` is `False` for any 4xx response — fixed with `if r is None`

## Changes

- `docker_challenges/functions/containers.py` — `delete_container()`: `if r is None` guard + 404 → `True`
- `docker_challenges/functions/services.py` — `delete_service()`: same pattern; corrected return type annotation
- `docker_challenges/api/api.py` — `_create_docker_instance()`: `data is None` guard before `json.loads`
- `tests/test_container_workflow.py` — regression tests with `bool(response) = False` to prevent 4xx short-circuit bug recurring

## Test plan

- [x] `pytest tests/ -q` — 249 tests pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Manual: stale tracker entries clear via revoke when container no longer exists on host