### PR TITLE
fix(secrets): match Docker secrets by name instead of Swarm ID

### DIFF
--- a/docker_challenges/api/api.py
+++ b/docker_challenges/api/api.py
@@ -491,7 +491,7 @@ class SecretAPI(Resource):
         docker = DockerConfig.query.filter_by(id=1).first()
         swarm = is_swarm_mode(docker)
         secrets = get_secrets(docker) if swarm else []
-        data = [{"name": i["Name"], "id": i["ID"]} for i in secrets]
+        data = [{"name": i["Name"], "id": i["Name"]} for i in secrets]
         return {"success": True, "data": data, "swarm_mode": swarm}
 
     @admins_only
@@ -530,7 +530,7 @@ class SecretAPI(Resource):
         username = user.name if user else "Unknown"
         logging.info("Admin '%s' created secret '%s' (ID: %s)", username, secret_name, secret_id)
 
-        return {"success": True, "data": {"id": secret_id, "name": secret_name}}, 201
+        return {"success": True, "data": {"id": secret_name, "name": secret_name}}, 201
 
     @admins_only
     def delete(self, secret_id):

--- a/tests/test_api_secret_endpoints.py
+++ b/tests/test_api_secret_endpoints.py
@@ -42,8 +42,8 @@ class TestSecretAPIGet:
         assert result == {
             "success": True,
             "data": [
-                {"name": "my_secret", "id": "sec1"},
-                {"name": "db_pass", "id": "sec2"},
+                {"name": "my_secret", "id": "my_secret"},
+                {"name": "db_pass", "id": "db_pass"},
             ],
             "swarm_mode": True,
         }
@@ -193,7 +193,7 @@ class TestSecretAPIPost:
 
         assert status == 201
         assert result["success"] is True
-        assert result["data"]["id"] == "sec_new_id"
+        assert result["data"]["id"] == "new_secret"
         assert result["data"]["name"] == "new_secret"
 
     @pytest.mark.medium


### PR DESCRIPTION
## Summary

- `_build_secrets_list()` now matches secrets by **Name** (primary) with a **Swarm ID fallback** for existing DB entries, fixing silent failures after secret rotation
- API GET/POST endpoints return `Name` as the `id` field so newly saved challenges store stable names going forward
- Legacy entries (stored Swarm IDs) continue to work but log a deprecation warning prompting admins to re-save

## Root Cause

`_build_secrets_list()` matched `config["id"]` (stored Swarm ID) against `secret["ID"]` (live Swarm ID). After secret rotation the Swarm ID changes but the Name stays the same, so the match failed silently and containers started with an empty `/run/secrets/`.

## Test Plan

- [ ] `pytest tests/test_secrets_parser.py` — name-based matching, legacy ID fallback, missing secret warning
- [ ] `pytest tests/test_api_secret_endpoints.py` — API returns Name as `id`
- [ ] `pytest tests/` — full suite green (251 tests)
- [ ] `pre-commit run --all-files` — all hooks pass
- [ ] Manual: create service challenge with secrets via `docker-compose.test.yml`, verify `/run/secrets/` is populated