### PR TITLE
bump: version 4.0.2 → 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [unreleased]: https://github.com/shiftysheep/CTFd-Docker-Challenges/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/shiftysheep/CTFd-Docker-Challenges/releases/tag/v1.0.0
 
+## v4.0.3 (2026-02-22)
+
+### Fix
+
+- **secrets**: match Docker secrets by name instead of Swarm ID (#33)
+
 ## v4.0.2 (2026-02-22)
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plugin for CTFd allows competing teams/users to start dockerized images for
 
 > **For Contributors**: See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code quality standards, and contribution guidelines.
 
-## Version 4.0.2
+## Version 4.0.3
 
 **Latest Update**: Migrated to Alpine.js and Bootstrap 5 for CTFd 3.8.0+ (core theme)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctfd-docker-challenges"
-version = "4.0.2"
+version = "4.0.3"
 description = "Docker-based challenge support for CTFd"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -396,7 +396,7 @@ toml = [
 
 [[package]]
 name = "ctfd-docker-challenges"
-version = "4.0.2"
+version = "4.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
Patch bump for fix(secrets): match Docker secrets by name instead of Swarm ID (#33).