### PR TITLE
ci: require version bump before merging PRs to master

### DIFF
--- a/.github/workflows/version-bump-check.yml
+++ b/.github/workflows/version-bump-check.yml
@@ -1,0 +1,38 @@
+name: Version Bump Check
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  check-version:
+    name: Verify version is bumped
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compare versions
+        run: |
+          PR_VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          BASE_VERSION=$(git show origin/master:pyproject.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+          echo "Base (master): $BASE_VERSION"
+          echo "PR branch:     $PR_VERSION"
+
+          if [ "$PR_VERSION" = "$BASE_VERSION" ]; then
+            echo ""
+            echo "ERROR: Version has not been bumped."
+            echo "Run 'cz bump' before opening this PR."
+            exit 1
+          fi
+
+          python3 - <<EOF
+          from packaging.version import Version
+          pr = Version("$PR_VERSION")
+          base = Version("$BASE_VERSION")
+          if pr <= base:
+              raise SystemExit(f"ERROR: PR version ({pr}) must be greater than base ({base}).")
+          print(f"OK: {base} → {pr}")
+          EOF


### PR DESCRIPTION
Adds a GitHub Actions check that blocks merging any PR to master if the version in `pyproject.toml` hasn't been bumped above the current master version. Uses `packaging.version` for proper semver comparison. Run `cz bump` on your branch before opening a PR.