### PR TITLE
fix: restore logic: all support by removing attempt/fail overrides

### DIFF
--- a/docker_challenges/models/container.py
+++ b/docker_challenges/models/container.py
@@ -11,11 +11,9 @@ from CTFd.models import (
     Tags,
     db,
 )
-from CTFd.plugins.challenges import BaseChallenge, ChallengeResponse
-from CTFd.plugins.flags import get_flag_class
+from CTFd.plugins.challenges import BaseChallenge
 from CTFd.utils.config import is_teams_mode
 from CTFd.utils.uploads import delete_file
-from CTFd.utils.user import get_ip
 from flask import Blueprint
 
 from ..functions.containers import delete_container
@@ -168,39 +166,18 @@ class DockerChallengeType(BaseChallenge):
         db.session.commit()
         return challenge
 
-    @staticmethod
-    def attempt(challenge, request):
-        """
-        This method is used to check whether a given input is right or wrong. It does not make any changes and should
-        return a boolean for correctness and a string to be shown to the user. It is also in charge of parsing the
-        user's input from the request itself.
-
-        :param challenge: The Challenge object from the database
-        :param request: The request the user submitted
-        :return: (boolean, string)
-        """
-        data = request.form or request.get_json()
-        logging.debug(request.get_json())
-        logging.debug(data)
-        submission = data["submission"].strip()
-        flags = Flags.query.filter_by(challenge_id=challenge.id).all()
-        for flag in flags:
-            if get_flag_class(flag.type).compare(flag, submission):
-                return ChallengeResponse(status="correct", message="Correct")
-        return ChallengeResponse(status="incorrect", message="Incorrect")
-
-    @staticmethod
-    def solve(user, team, challenge, request):
+    @classmethod
+    def solve(cls, user, team, challenge, request):
         """
         This method is used to insert Solves into the database in order to mark a challenge as solved.
+        Performs docker container cleanup before delegating to the base implementation.
 
+        :param user: The User object from the database
         :param team: The Team object from the database
-        :param chal: The Challenge object from the database
+        :param challenge: The Challenge object from the database
         :param request: The request the user submitted
         :return:
         """
-        data = request.form or request.get_json()
-        submission = data["submission"].strip()
         docker = DockerConfig.query.filter_by(id=1).first()
         try:
             cleanup_container_on_solve(
@@ -209,35 +186,6 @@ class DockerChallengeType(BaseChallenge):
         except Exception as e:
             # Container may have already been deleted or never created
             logging.debug("Failed to delete container on solve: %s", e)
-        solve = Solves(
-            user_id=user.id,
-            team_id=team.id if team else None,
-            challenge_id=challenge.id,
-            ip=get_ip(req=request),
-            provided=submission,
+        super(DockerChallengeType, cls).solve(  # noqa: UP008
+            user=user, team=team, challenge=challenge, request=request
         )
-        db.session.add(solve)
-        db.session.commit()
-
-    @staticmethod
-    def fail(user, team, challenge, request):
-        """
-        This method is used to insert Fails into the database in order to mark an answer incorrect.
-
-        :param team: The Team object from the database
-        :param chal: The Challenge object from the database
-        :param request: The request the user submitted
-        :return:
-        """
-        data = request.form or request.get_json()
-        submission = data["submission"].strip()
-        wrong = Fails(
-            user_id=user.id,
-            team_id=team.id if team else None,
-            challenge_id=challenge.id,
-            ip=get_ip(request),
-            provided=submission,
-        )
-        db.session.add(wrong)
-        db.session.commit()
-        # db.session.close()

--- a/docker_challenges/models/service.py
+++ b/docker_challenges/models/service.py
@@ -11,11 +11,9 @@ from CTFd.models import (
     Tags,
     db,
 )
-from CTFd.plugins.challenges import BaseChallenge, ChallengeResponse
-from CTFd.plugins.flags import get_flag_class
+from CTFd.plugins.challenges import BaseChallenge
 from CTFd.utils.config import is_teams_mode
 from CTFd.utils.uploads import delete_file
-from CTFd.utils.user import get_ip
 from flask import Blueprint
 
 from ..functions.general import cleanup_container_on_solve, resolve_exposed_ports_from_image
@@ -182,40 +180,18 @@ class DockerServiceChallengeType(BaseChallenge):
         db.session.commit()
         return challenge
 
-    @staticmethod
-    def attempt(challenge, request):
-        """
-        This method is used to check whether a given input is right or wrong. It does not make any changes and should
-        return a boolean for correctness and a string to be shown to the user. It is also in charge of parsing the
-        user's input from the request itself.
-
-        :param challenge: The Challenge object from the database
-        :param request: The request the user submitted
-        :return: (boolean, string)
-        """
-
-        data = request.form or request.get_json()
-        logging.debug(request.get_json())
-        logging.debug(data)
-        submission = data["submission"].strip()
-        flags = Flags.query.filter_by(challenge_id=challenge.id).all()
-        for flag in flags:
-            if get_flag_class(flag.type).compare(flag, submission):
-                return ChallengeResponse(status="correct", message="Correct")
-        return ChallengeResponse(status="incorrect", message="Incorrect")
-
-    @staticmethod
-    def solve(user, team, challenge, request):
+    @classmethod
+    def solve(cls, user, team, challenge, request):
         """
         This method is used to insert Solves into the database in order to mark a challenge as solved.
+        Performs docker service cleanup before delegating to the base implementation.
 
+        :param user: The User object from the database
         :param team: The Team object from the database
-        :param chal: The Challenge object from the database
+        :param challenge: The Challenge object from the database
         :param request: The request the user submitted
         :return:
         """
-        data = request.form or request.get_json()
-        submission = data["submission"].strip()
         docker = DockerConfig.query.filter_by(id=1).first()
         try:
             cleanup_container_on_solve(
@@ -224,34 +200,6 @@ class DockerServiceChallengeType(BaseChallenge):
         except Exception as e:
             # Service may have already been deleted or never created
             logging.debug("Failed to delete service on solve: %s", e)
-        solve = Solves(
-            user_id=user.id,
-            team_id=team.id if team else None,
-            challenge_id=challenge.id,
-            ip=get_ip(req=request),
-            provided=submission,
+        super(DockerServiceChallengeType, cls).solve(  # noqa: UP008
+            user=user, team=team, challenge=challenge, request=request
         )
-        db.session.add(solve)
-        db.session.commit()
-
-    @staticmethod
-    def fail(user, team, challenge, request):
-        """
-        This method is used to insert Fails into the database in order to mark an answer incorrect.
-
-        :param team: The Team object from the database
-        :param chal: The Challenge object from the database
-        :param request: The request the user submitted
-        :return:
-        """
-        data = request.form or request.get_json()
-        submission = data["submission"].strip()
-        wrong = Fails(
-            user_id=user.id,
-            team_id=team.id if team else None,
-            challenge_id=challenge.id,
-            ip=get_ip(request),
-            provided=submission,
-        )
-        db.session.add(wrong)
-        db.session.commit()

--- a/tests/stubs/ctfd_stubs.py
+++ b/tests/stubs/ctfd_stubs.py
@@ -116,7 +116,18 @@ def register_plugin_assets_directory(*args, **kwargs):
 # --- CTFd Plugins ---
 class BaseChallenge:
     """Stub for CTFd.plugins.challenges.BaseChallenge."""
-    pass
+
+    @classmethod
+    def attempt(cls, challenge, request):
+        pass
+
+    @classmethod
+    def solve(cls, user, team, challenge, request):
+        pass
+
+    @classmethod
+    def fail(cls, user, team, challenge, request):
+        pass
 
 
 class ChallengeResponse:

--- a/tests/test_challenge_logic.py
+++ b/tests/test_challenge_logic.py
@@ -1,0 +1,153 @@
+"""Tests verifying that logic: all / logic: any dispatch is handled by BaseChallenge.
+
+The docker plugin must NOT override attempt() or fail() — those overrides bypassed
+CTFd 3.8.0's logic dispatch, causing challenges with logic: all to be solved after
+just one correct flag submission.
+
+solve() IS overridden to perform container/service cleanup, but it must delegate
+Solves record creation to super().solve().
+"""
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from docker_challenges.models.container import DockerChallengeType
+from docker_challenges.models.service import DockerServiceChallengeType
+
+
+# ---------------------------------------------------------------------------
+# attempt() — must NOT be overridden
+# ---------------------------------------------------------------------------
+
+
+def test_container_does_not_override_attempt():
+    """DockerChallengeType must inherit attempt() from BaseChallenge."""
+    assert "attempt" not in DockerChallengeType.__dict__
+
+
+def test_service_does_not_override_attempt():
+    """DockerServiceChallengeType must inherit attempt() from BaseChallenge."""
+    assert "attempt" not in DockerServiceChallengeType.__dict__
+
+
+# ---------------------------------------------------------------------------
+# fail() — must NOT be overridden
+# ---------------------------------------------------------------------------
+
+
+def test_container_does_not_override_fail():
+    """DockerChallengeType must inherit fail() from BaseChallenge."""
+    assert "fail" not in DockerChallengeType.__dict__
+
+
+def test_service_does_not_override_fail():
+    """DockerServiceChallengeType must inherit fail() from BaseChallenge."""
+    assert "fail" not in DockerServiceChallengeType.__dict__
+
+
+# ---------------------------------------------------------------------------
+# solve() — must call cleanup then delegate to super().solve()
+# ---------------------------------------------------------------------------
+
+
+def _make_solve_fixtures():
+    user = MagicMock()
+    user.id = 1
+    team = MagicMock()
+    team.id = 2
+    challenge = MagicMock()
+    challenge.id = 10
+    request = MagicMock()
+    return user, team, challenge, request
+
+
+def test_container_solve_calls_cleanup_then_super():
+    """DockerChallengeType.solve() cleans up container then delegates to super()."""
+    user, team, challenge, request = _make_solve_fixtures()
+
+    with (
+        patch(
+            "docker_challenges.models.container.DockerConfig"
+        ) as mock_config,
+        patch(
+            "docker_challenges.models.container.cleanup_container_on_solve"
+        ) as mock_cleanup,
+        patch(
+            "docker_challenges.models.container.delete_container"
+        ) as mock_delete,
+        patch(
+            "docker_challenges.models.container.is_teams_mode", return_value=False
+        ),
+        patch(
+            "tests.stubs.ctfd_stubs.BaseChallenge.solve"
+        ) as mock_base_solve,
+    ):
+        mock_config.query.filter_by.return_value.first.return_value = MagicMock()
+
+        DockerChallengeType.solve(user=user, team=team, challenge=challenge, request=request)
+
+        mock_cleanup.assert_called_once()
+        # super(DockerChallengeType, cls).solve() dispatches to BaseChallenge.solve
+        mock_base_solve.assert_called_once_with(
+            user=user, team=team, challenge=challenge, request=request
+        )
+
+
+def test_service_solve_calls_cleanup_then_super():
+    """DockerServiceChallengeType.solve() cleans up service then delegates to super()."""
+    user, team, challenge, request = _make_solve_fixtures()
+
+    with (
+        patch(
+            "docker_challenges.models.service.DockerConfig"
+        ) as mock_config,
+        patch(
+            "docker_challenges.models.service.cleanup_container_on_solve"
+        ) as mock_cleanup,
+        patch(
+            "docker_challenges.models.service.delete_service"
+        ) as mock_delete,
+        patch(
+            "docker_challenges.models.service.is_teams_mode", return_value=False
+        ),
+        patch(
+            "tests.stubs.ctfd_stubs.BaseChallenge.solve"
+        ) as mock_base_solve,
+    ):
+        mock_config.query.filter_by.return_value.first.return_value = MagicMock()
+
+        DockerServiceChallengeType.solve(user=user, team=team, challenge=challenge, request=request)
+
+        mock_cleanup.assert_called_once()
+        mock_base_solve.assert_called_once_with(
+            user=user, team=team, challenge=challenge, request=request
+        )
+
+
+def test_container_solve_records_solve_even_if_cleanup_fails():
+    """A container cleanup failure must not prevent the Solves record from being created."""
+    user, team, challenge, request = _make_solve_fixtures()
+
+    with (
+        patch(
+            "docker_challenges.models.container.DockerConfig"
+        ) as mock_config,
+        patch(
+            "docker_challenges.models.container.cleanup_container_on_solve",
+            side_effect=RuntimeError("container gone"),
+        ),
+        patch(
+            "docker_challenges.models.container.is_teams_mode", return_value=False
+        ),
+        patch(
+            "tests.stubs.ctfd_stubs.BaseChallenge.solve"
+        ) as mock_base_solve,
+    ):
+        mock_config.query.filter_by.return_value.first.return_value = MagicMock()
+
+        # Must not raise even though cleanup raises
+        DockerChallengeType.solve(user=user, team=team, challenge=challenge, request=request)
+
+        mock_base_solve.assert_called_once_with(
+            user=user, team=team, challenge=challenge, request=request
+        )


### PR DESCRIPTION
## Summary

- **Root cause**: \`DockerChallengeType\` and \`DockerServiceChallengeType\` both overrode \`attempt()\` with a hardcoded loop that returned \`"correct"\` on the first matching flag, bypassing CTFd 3.8.0's \`logic\` dispatch. Challenges configured with \`logic: all\` (e.g. Burp Suite, Busters) were therefore solved after submitting just one flag.
- **Fix**: Remove both \`attempt()\` overrides — \`BaseChallenge.attempt()\` now handles \`logic: any\`, \`logic: all\`, and \`logic: team\` correctly.
- **\`solve()\` refactored** from \`@staticmethod\` to \`@classmethod\` so it can delegate to \`super().solve()\` for Solves record creation while still running container/service cleanup first. \`# noqa: UP008\` suppresses ruff's "use \`super()\` without args" lint where the explicit form is required to keep \`cls\` referenced (satisfying vulture).
- **\`fail()\` removed** — both overrides were byte-for-byte identical to \`BaseChallenge.fail()\` with no docker-specific logic.
- **Unused imports cleaned up**: \`ChallengeResponse\`, \`get_flag_class\`, \`get_ip\` removed from both model files.

## Test plan

- [x] \`uv run pytest\` — 258/258 pass (no regressions)
- [x] \`uv run pytest tests/test_challenge_logic.py -v\` — 7/7 new tests pass:
  - \`DockerChallengeType\` / \`DockerServiceChallengeType\` do NOT define \`attempt\` (inherited from \`BaseChallenge\`)
  - Neither type defines \`fail\`
  - \`solve()\` calls \`cleanup_container_on_solve\` then delegates to \`super().solve()\`
  - Container cleanup failure does not prevent the solve from being recorded
- [x] Deploy updated plugin to CTFd and verify:
  - \`logic: any\` challenges still solve on first correct flag (regression check: all existing challenges unaffected)
  - \`logic: all\` challenge returns \`status: "partial"\` on first correct flag, \`status: "correct"\` only after all flags submitted — confirmed via live integration test against CTFd 3.8.2